### PR TITLE
[FEAT] adds call and route to index token account balance

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@fastify/helmet": "^11.1.1",
     "@urql/core": "^4.1.3",
+    "ajv": "^8.12.0",
     "axios": "^1.5.1",
     "dotenv-expand": "^10.0.0",
     "fastify": "^4.23.2",

--- a/src/helper/test-helper.ts
+++ b/src/helper/test-helper.ts
@@ -38,6 +38,8 @@ const mercurySession = {
 };
 
 const pubKey = "GDUBMXMABE7UOZSGYJ5ONE7UYAEHKK3JOX7HZQGNZ7NYTZPPP4AJ2GQJ";
+const tokenBalanceLedgerKey =
+  "AAAAEAAAAAEAAAABAAAAEQAAAAEAAAACAAAADwAAAAdiYWxhbmNlAAAAAA4AAAAHQmFsYW5jZQAAAAAPAAAAB2FkZHJlc3MAAAAADgAAADhHRFVCTVhNQUJFN1VPWlNHWUo1T05FN1VZQUVIS0szSk9YN0haUUdOWjdOWVRaUFBQNEFKMkdRSg==";
 
 const queryMockResponse = {
   [mutation.authenticate]: {
@@ -52,6 +54,30 @@ const queryMockResponse = {
         id: 28,
       },
     },
+  },
+  "query.getAccountBalances": {
+    edges: [
+      {
+        node: {
+          contractId: "contract-id-1",
+          keyXdr: tokenBalanceLedgerKey,
+          valueXdr: "value-xdr",
+          ledgerTimestamp: "timestamp",
+          ledger: "1",
+          entryDurability: "persistent",
+        },
+      },
+      {
+        node: {
+          contractId: "contract-id-2",
+          keyXdr: tokenBalanceLedgerKey,
+          valueXdr: "value-xdr",
+          ledgerTimestamp: "timestamp",
+          ledger: "1",
+          entryDurability: "persistent",
+        },
+      },
+    ],
   },
   [query.getAccountHistory]: {
     eventByContractId: {
@@ -87,6 +113,7 @@ const queryMockResponse = {
 };
 
 jest.spyOn(client, "query").mockImplementation((_query: any): any => {
+  console.log(_query);
   switch (_query) {
     case mutation.authenticate: {
       return Promise.resolve({
@@ -103,6 +130,15 @@ jest.spyOn(client, "query").mockImplementation((_query: any): any => {
     case query.getAccountHistory: {
       return Promise.resolve({
         data: queryMockResponse[query.getAccountHistory],
+        error: null,
+      });
+    }
+    case query.getAccountBalances(tokenBalanceLedgerKey, [
+      "contract-id-1",
+      "contract-id-2",
+    ]): {
+      return Promise.resolve({
+        data: queryMockResponse["query.getAccountBalances"],
         error: null,
       });
     }

--- a/src/helper/test-helper.ts
+++ b/src/helper/test-helper.ts
@@ -113,7 +113,6 @@ const queryMockResponse = {
 };
 
 jest.spyOn(client, "query").mockImplementation((_query: any): any => {
-  console.log(_query);
   switch (_query) {
     case mutation.authenticate: {
       return Promise.resolve({

--- a/src/helper/validate.ts
+++ b/src/helper/validate.ts
@@ -1,0 +1,12 @@
+import { StrKey } from "soroban-client";
+
+const isContractId = (contractId: string) => {
+  try {
+    StrKey.decodeContract(contractId);
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
+export { isContractId };

--- a/src/route/index.ts
+++ b/src/route/index.ts
@@ -64,7 +64,7 @@ export function initApiServer(mercuryClient: MercuryClient) {
           reply
         ) => {
           const { contract_id, pub_key } = request.body;
-          const { data, error } = await mercuryClient.addNewTokenSubscription(
+          const { data, error } = await mercuryClient.tokenSubscription(
             contract_id,
             pub_key
           );
@@ -100,7 +100,46 @@ export function initApiServer(mercuryClient: MercuryClient) {
           reply
         ) => {
           const { pub_key } = request.body;
-          const { data, error } = await mercuryClient.addNewAccountSubscription(
+          const { data, error } = await mercuryClient.accountSubscription(
+            pub_key
+          );
+          if (error) {
+            reply.code(400).send(error);
+          } else {
+            reply.code(200).send(data);
+          }
+        },
+      });
+
+      instance.route({
+        method: "POST",
+        url: "/subscription/balance",
+        schema: {
+          body: {
+            type: "object",
+            properties: {
+              contract_id: { type: "string" },
+              pub_key: { type: "string" },
+            },
+          },
+          response: {
+            200: {
+              type: "object",
+              properties: {
+                data: { type: "object" },
+              },
+            },
+          },
+        },
+        handler: async (
+          request: FastifyRequest<{
+            Body: { pub_key: string; contract_id: string };
+          }>,
+          reply
+        ) => {
+          const { pub_key, contract_id } = request.body;
+          const { data, error } = await mercuryClient.tokenBalanceSubscription(
+            contract_id,
             pub_key
           );
           if (error) {

--- a/src/route/index.ts
+++ b/src/route/index.ts
@@ -178,6 +178,7 @@ export function initApiServer(mercuryClient: MercuryClient) {
           reply
         ) => {
           const { pub_key, contract_id } = request.body;
+          // TODO: once classic subs include balance, add query
           const { data, error } = await mercuryClient.tokenBalanceSubscription(
             contract_id,
             pub_key

--- a/src/route/index.ts
+++ b/src/route/index.ts
@@ -153,7 +153,7 @@ export function initApiServer(mercuryClient: MercuryClient) {
 
       instance.route({
         method: "POST",
-        url: "/subscription/balance",
+        url: "/subscription/token-balance",
         schema: {
           body: {
             type: "object",

--- a/src/route/index.ts
+++ b/src/route/index.ts
@@ -178,7 +178,6 @@ export function initApiServer(mercuryClient: MercuryClient) {
           reply
         ) => {
           const { pub_key, contract_id } = request.body;
-          // TODO: once classic subs include balance, add query
           const { data, error } = await mercuryClient.tokenBalanceSubscription(
             contract_id,
             pub_key

--- a/src/route/validators.ts
+++ b/src/route/validators.ts
@@ -1,0 +1,48 @@
+import Ajv, { AnySchemaObject, ValidateFunction } from "ajv";
+
+const ajv = new Ajv({
+  removeAdditional: true,
+  useDefaults: true,
+  coerceTypes: true,
+});
+
+ajv.addKeyword("validator", {
+  compile: (schema: any, parentSchema: AnySchemaObject) =>
+    function validate(data: ValidateFunction) {
+      if (typeof schema === "function") {
+        const valid = schema(data);
+        if (!valid) {
+          validate.errors = [
+            {
+              keyword: "validate",
+              message: `: ${data} fails validation`,
+              params: { keyword: "validate" },
+            },
+          ];
+        }
+        return valid;
+      } else if (
+        typeof schema === "object" &&
+        Array.isArray(schema) &&
+        schema.every((f) => typeof f === "function")
+      ) {
+        const [f, errorMessage] = schema;
+        const valid = f(data);
+        if (!valid) {
+          validate.errors = [
+            {
+              keyword: "validate",
+              message: ": " + errorMessage(schema, parentSchema, data),
+              params: { keyword: "validate" },
+            },
+          ];
+        }
+        return valid;
+      } else {
+        throw new Error("Invalid definition for custom validator");
+      }
+    },
+  errors: true,
+} as any);
+
+export { ajv };

--- a/src/route/validators.ts
+++ b/src/route/validators.ts
@@ -1,4 +1,8 @@
-import Ajv, { AnySchemaObject, ValidateFunction } from "ajv";
+import Ajv, {
+  AnySchemaObject,
+  ValidateFunction,
+  SchemaValidateFunction,
+} from "ajv";
 
 const ajv = new Ajv({
   removeAdditional: true,
@@ -7,12 +11,12 @@ const ajv = new Ajv({
 });
 
 ajv.addKeyword("validator", {
-  compile: (schema: any, parentSchema: AnySchemaObject) =>
-    function validate(data: ValidateFunction) {
+  compile: (schema: any, parentSchema: AnySchemaObject) => {
+    return function validate(data: ValidateFunction) {
       if (typeof schema === "function") {
         const valid = schema(data);
         if (!valid) {
-          validate.errors = [
+          (validate as SchemaValidateFunction).errors = [
             {
               keyword: "validate",
               message: `: ${data} fails validation`,
@@ -29,7 +33,7 @@ ajv.addKeyword("validator", {
         const [f, errorMessage] = schema;
         const valid = f(data);
         if (!valid) {
-          validate.errors = [
+          (validate as SchemaValidateFunction).errors = [
             {
               keyword: "validate",
               message: ": " + errorMessage(schema, parentSchema, data),
@@ -41,7 +45,8 @@ ajv.addKeyword("validator", {
       } else {
         throw new Error("Invalid definition for custom validator");
       }
-    },
+    };
+  },
   errors: true,
 } as any);
 

--- a/src/service/mercury/index.test.ts
+++ b/src/service/mercury/index.test.ts
@@ -4,6 +4,7 @@ import {
   queryMockResponse,
   pubKey,
 } from "../../helper/test-helper";
+import { xdr } from "soroban-client";
 
 describe("Mercury Service", () => {
   it("can renew a token", async () => {
@@ -30,5 +31,33 @@ describe("Mercury Service", () => {
     expect(pubKey).toEqual(
       data?.data.createFullAccountSubscription.fullAccountSubscription.publickey
     );
+  });
+
+  it("can build a balance ledger key for a pub key", async () => {
+    const ledgerKey = mockMercuryClient.tokenBalanceKey(pubKey);
+    const scVal = xdr.ScVal.fromXDR(
+      Buffer.from(ledgerKey, "base64")
+    ).value() as xdr.ScVal[];
+    const hasPubKey = scVal.map((scVal) => {
+      const inner = scVal.value() as xdr.ScMapEntry[];
+      return inner.some((v) => {
+        const mapVal = v.val();
+        return mapVal.value()?.toString() === pubKey;
+      });
+    });
+    expect(hasPubKey).toBeTruthy();
+  });
+
+  it("can fetch account balances by pub key", async () => {
+    const contracts = ["contract-id-1", "contract-id-2"];
+    const { data } = await mockMercuryClient.getAccountBalances(
+      pubKey,
+      contracts
+    );
+    expect(
+      data?.data.edges.map(
+        (node: { node: Record<string, string> }) => node.node.contractId
+      )
+    ).toEqual(contracts);
   });
 });

--- a/src/service/mercury/index.test.ts
+++ b/src/service/mercury/index.test.ts
@@ -26,7 +26,7 @@ describe("Mercury Service", () => {
   });
 
   it("can add new full account subscription", async () => {
-    const { data } = await mockMercuryClient.addNewAccountSubscription(pubKey);
+    const { data } = await mockMercuryClient.accountSubscription(pubKey);
     expect(pubKey).toEqual(
       data?.data.createFullAccountSubscription.fullAccountSubscription.publickey
     );

--- a/src/service/mercury/index.ts
+++ b/src/service/mercury/index.ts
@@ -216,6 +216,7 @@ export class MercuryClient {
   };
 
   getAccountBalances = async (pubKey: string, contractIds: string[]) => {
+    // TODO: once classic subs include balance, add query
     try {
       const data = await this.urqlClient.query(
         query.getAccountBalances(this.tokenBalanceKey(pubKey), contractIds),

--- a/src/service/mercury/index.ts
+++ b/src/service/mercury/index.ts
@@ -44,6 +44,7 @@ export class MercuryClient {
   }
 
   tokenBalanceKey = (pubKey: string) => {
+    // { "vec": [{ "symbol": "Balance" }, { "Address": <...pubkey...> }] }
     const sigScVal = nativeToScVal(
       {
         balance: "Balance",

--- a/src/service/mercury/index.ts
+++ b/src/service/mercury/index.ts
@@ -1,7 +1,7 @@
 import { Client } from "@urql/core";
 import axios from "axios";
 import { Logger } from "pino";
-import { nativeToScVal } from "soroban-client";
+import { nativeToScVal, xdr } from "soroban-client";
 import { mutation, query } from "./queries";
 
 export interface NewEventSubscriptionPayload {
@@ -150,10 +150,22 @@ export class MercuryClient {
 
   tokenBalanceSubscription = async (contractId: string, pubKey: string) => {
     try {
+      const sigScVal = nativeToScVal(
+        {
+          balance: "Balance",
+          address: pubKey,
+        },
+        {
+          type: {
+            balance: ["symbol", null],
+            address: ["symbol", null],
+          },
+        }
+      );
       const entrySub = {
         contract_id: contractId,
-        max_entry_size: 1000,
-        key_xdr: pubKey, // TODO: build entry for pubkey's balance
+        max_entry_size: 100,
+        key_xdr: xdr.ScVal.scvVec([sigScVal]).toXDR("base64"),
       };
 
       const config = {

--- a/src/service/mercury/queries.ts
+++ b/src/service/mercury/queries.ts
@@ -31,6 +31,25 @@ export const query = {
       }
     }
   `,
+  getAccountBalances: (ledgerKey: string, contractIds: string[]) => `
+    query AccountBalances {
+      ${contractIds.map(
+        (id) =>
+          `
+        entryUpdateByContractIdAndKey(ledgerKey: ${ledgerKey}, contract: ${id}) {
+          nodes {
+            contractId
+            keyXdr
+            valueXdr
+            ledgerTimestamp
+            ledger
+            entryDurability
+          }
+        }
+        `
+      )}
+    }
+  `,
   getAccountHistory: `
     query GetAccountHistory {
       eventByTopic(t1: "AAAADgAAAARtaW50") {

--- a/src/stub.test.ts
+++ b/src/stub.test.ts
@@ -1,5 +1,0 @@
-describe("Stub test", () => {
-  it("passes as placeholder", () => {
-    expect(true).toBeTruthy;
-  });
-});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1015,7 +1015,7 @@ ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.10.0, ajv@^8.11.0:
+ajv@^8.0.0, ajv@^8.10.0, ajv@^8.11.0, ajv@^8.12.0:
   version "8.12.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
   integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==


### PR DESCRIPTION
Adds new Mercury service calls to build a token balance key, and to subscribe to token balances.

New Route:
GET `/account-balances/:pub-key`
POST `/subscription/token-balance`

Adds customer validator to check that arguments can resolve to contract addresses, `isContractId`.

Todo:
Mercury is currently working on adding classic asset balances to full account subscriptions, once that feature is live then we can add the query to fetch balances to `MercuryService.getAccountBalances`
