### PR TITLE
Feat/token detail cache

### DIFF
--- a/src/helper/soroban-rpc.ts
+++ b/src/helper/soroban-rpc.ts
@@ -1,0 +1,112 @@
+import {
+  Networks,
+  Server,
+  TransactionBuilder,
+  BASE_FEE,
+  Contract,
+  TimeoutInfinite,
+  Transaction,
+  Memo,
+  MemoType,
+  Operation,
+  scValToNative,
+} from "soroban-client";
+
+type NetworkNames = keyof typeof Networks;
+
+const SOROBAN_RPC_URLS: { [key in keyof typeof Networks]?: string } = {
+  TESTNET: "https://soroban-testnet.stellar.org/",
+};
+
+const getServer = async (network: NetworkNames) => {
+  const serverUrl = SOROBAN_RPC_URLS[network];
+  if (!serverUrl) {
+    throw new Error("network not supported");
+  }
+
+  return new Server(serverUrl, {
+    allowHttp: serverUrl.startsWith("http://"),
+  });
+};
+
+const getTxBuilder = async (
+  pubKey: string,
+  network: NetworkNames,
+  server: Server
+) => {
+  const sourceAccount = await server.getAccount(pubKey);
+  return new TransactionBuilder(sourceAccount, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks[network],
+  });
+};
+
+const simulateTx = async <ArgType>(
+  tx: Transaction<Memo<MemoType>, Operation[]>,
+  server: Server
+): Promise<ArgType> => {
+  const simulatedTX = await server.simulateTransaction(tx);
+  if ("result" in simulatedTX && simulatedTX.result !== undefined) {
+    return scValToNative(simulatedTX.result.retval);
+  }
+
+  throw new Error("Invalid response from simulateTransaction");
+};
+
+const getTokenDecimals = async (
+  contractId: string,
+  server: Server,
+  builder: TransactionBuilder
+) => {
+  const contract = new Contract(contractId);
+
+  const tx = builder
+    .addOperation(contract.call("decimals"))
+    .setTimeout(TimeoutInfinite)
+    .build();
+
+  const result = await simulateTx<number>(tx, server);
+  return result;
+};
+
+const getTokenName = async (
+  contractId: string,
+  server: Server,
+  builder: TransactionBuilder
+) => {
+  const contract = new Contract(contractId);
+
+  const tx = builder
+    .addOperation(contract.call("name"))
+    .setTimeout(TimeoutInfinite)
+    .build();
+
+  const result = await simulateTx<string>(tx, server);
+  return result;
+};
+
+const getTokenSymbol = async (
+  contractId: string,
+  server: Server,
+  builder: TransactionBuilder
+) => {
+  const contract = new Contract(contractId);
+
+  const tx = builder
+    .addOperation(contract.call("symbol"))
+    .setTimeout(TimeoutInfinite)
+    .build();
+
+  const result = await simulateTx<string>(tx, server);
+  return result;
+};
+
+export {
+  getServer,
+  getTokenDecimals,
+  getTokenName,
+  getTokenSymbol,
+  getTxBuilder,
+  simulateTx,
+  SOROBAN_RPC_URLS,
+};

--- a/src/helper/test-helper.ts
+++ b/src/helper/test-helper.ts
@@ -62,9 +62,9 @@ const queryMockResponse = {
     },
   },
   "query.getAccountBalances": {
-    edges: [
-      {
-        node: {
+    entryUpdateByContractIdAndKey: {
+      nodes: [
+        {
           contractId:
             "CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP",
           keyXdr: tokenBalanceLedgerKey,
@@ -73,9 +73,7 @@ const queryMockResponse = {
           ledger: "1",
           entryDurability: "persistent",
         },
-      },
-      {
-        node: {
+        {
           contractId:
             "CBGTG7XFRY3L6OKAUTR6KGDKUXUQBX3YDJ3QFDYTGVMOM7VV4O7NCODG",
           keyXdr: tokenBalanceLedgerKey,
@@ -84,8 +82,8 @@ const queryMockResponse = {
           ledger: "1",
           entryDurability: "persistent",
         },
-      },
-    ],
+      ],
+    },
   },
   [query.getAccountHistory]: {
     eventByContractId: {
@@ -185,6 +183,18 @@ const mockMercuryClient = new MercuryClient(
   renewClient,
   testLogger
 );
+
+jest
+  .spyOn(mockMercuryClient, "tokenDetails")
+  .mockImplementation(
+    (..._args: Parameters<MercuryClient["tokenDetails"]>): any => {
+      return {
+        name: "Test Contract",
+        decimals: 7,
+        symbol: "TST",
+      };
+    }
+  );
 async function getDevServer() {
   const server = initApiServer(mockMercuryClient, testLogger);
   await server.listen();

--- a/src/helper/test-helper.ts
+++ b/src/helper/test-helper.ts
@@ -186,19 +186,7 @@ const mockMercuryClient = new MercuryClient(
   testLogger
 );
 async function getDevServer() {
-  const config = {
-    hostname: "localhost",
-    mode: "development",
-    mercuryEmail: "info@mercury.io",
-    mercuryKey: "xxx",
-    mercuryPassword: "pass",
-    mercuryBackend: "backend",
-    mercuryGraphQL: "graph-ql",
-    mercuryUserId: "user-id",
-    redisConnectionName: "freighter",
-    redisPort: 6379,
-  };
-  const server = initApiServer(mockMercuryClient, config);
+  const server = initApiServer(mockMercuryClient, testLogger);
   await server.listen();
   return server;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,9 +60,8 @@ async function main() {
   };
 
   let redis = undefined;
-
   // use in-memory store in dev
-  if (config.mode !== "development") {
+  if (conf.mode !== "development") {
     redis = new Redis({
       connectionName: conf.redisConnectionName,
       host: conf.hostname,

--- a/src/route/index.test.ts
+++ b/src/route/index.test.ts
@@ -2,7 +2,7 @@ import { getDevServer, queryMockResponse, pubKey } from "../helper/test-helper";
 import { query } from "../service/mercury/queries";
 
 describe("API routes", () => {
-  describe.skip("/account-history/:pubKey", () => {
+  describe("/account-history/:pubKey", () => {
     it("can fetch an account history for a pub key", async () => {
       const server = await getDevServer();
       const response = await fetch(

--- a/src/route/index.test.ts
+++ b/src/route/index.test.ts
@@ -2,7 +2,7 @@ import { getDevServer, queryMockResponse, pubKey } from "../helper/test-helper";
 import { query } from "../service/mercury/queries";
 
 describe("API routes", () => {
-  describe("/account-history/:pubKey", () => {
+  describe.skip("/account-history/:pubKey", () => {
     it("can fetch an account history for a pub key", async () => {
       const server = await getDevServer();
       const response = await fetch(
@@ -37,11 +37,13 @@ describe("API routes", () => {
           (server?.server?.address() as any).port
         }/api/v1/account-balances/${pubKey}?contract_ids=CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP`
       );
-      const { data } = await response.json();
+      const data = await response.json();
       expect(response.status).toEqual(200);
-      expect(data.edges).toEqual(
-        queryMockResponse["query.getAccountBalances"].edges
-      );
+      for (const node of data) {
+        expect(node).toHaveProperty("contractId");
+        expect(node).toHaveProperty("keyXdr");
+        expect(node).toHaveProperty("valueXdr");
+      }
       server.close();
     });
 
@@ -60,11 +62,15 @@ describe("API routes", () => {
           params as any
         )}`
       );
-      const { data } = await response.json();
+      const data = await response.json();
       expect(response.status).toEqual(200);
-      expect(data.edges).toEqual(
-        queryMockResponse["query.getAccountBalances"].edges
-      );
+      expect(response.status).toEqual(200);
+      expect(data.length).toEqual(2);
+      for (const node of data) {
+        expect(node).toHaveProperty("contractId");
+        expect(node).toHaveProperty("keyXdr");
+        expect(node).toHaveProperty("valueXdr");
+      }
       server.close();
     });
 

--- a/src/route/index.ts
+++ b/src/route/index.ts
@@ -9,6 +9,7 @@ import { ajv } from "./validators";
 import { isContractId, isPubKey } from "../helper/validate";
 
 const API_VERSION = "v1";
+const NETWORK = "TESTNET"; // hardcode testnet for now, not sure how Mercury will change the schema for multi-network support yet
 
 export function initApiServer(
   mercuryClient: MercuryClient,
@@ -93,7 +94,8 @@ export function initApiServer(
           const contractIds = request.query["contract_ids"].split(",");
           const { data, error } = await mercuryClient.getAccountBalances(
             pubKey,
-            contractIds
+            contractIds,
+            NETWORK
           );
           if (error) {
             reply.code(400).send(error);
@@ -206,7 +208,8 @@ export function initApiServer(
           const { pub_key, contract_id } = request.body;
           const { data, error } = await mercuryClient.tokenBalanceSubscription(
             contract_id,
-            pub_key
+            pub_key,
+            NETWORK
           );
           if (error) {
             reply.code(400).send(error);

--- a/src/route/index.ts
+++ b/src/route/index.ts
@@ -1,29 +1,22 @@
 import Fastify, { FastifyRequest } from "fastify";
 import helmet from "@fastify/helmet";
 import rateLimiter from "@fastify/rate-limit";
-import Redis from "ioredis";
+import { Logger } from "pino";
+import { Redis } from "ioredis";
 
 import { MercuryClient } from "../service/mercury";
 import { ajv } from "./validators";
 import { isContractId, isPubKey } from "../helper/validate";
-import { Conf } from "../config";
 
 const API_VERSION = "v1";
 
-export function initApiServer(mercuryClient: MercuryClient, config: Conf) {
-  let redis = undefined;
-  if (config.mode !== "development") {
-    redis = new Redis({
-      connectionName: config.redisConnectionName,
-      host: config.hostname,
-      port: config.redisPort,
-      connectTimeout: 500,
-      maxRetriesPerRequest: 1,
-    });
-  }
-
+export function initApiServer(
+  mercuryClient: MercuryClient,
+  logger: Logger,
+  redis?: Redis
+) {
   const server = Fastify({
-    logger: true,
+    logger,
   });
   server.setValidatorCompiler(({ schema }) => {
     return ajv.compile(schema);

--- a/src/service/mercury/helpers/transformers.ts
+++ b/src/service/mercury/helpers/transformers.ts
@@ -12,6 +12,16 @@ interface MercuryAccountBalancesData {
   };
 }
 
+interface MercuryAllEntryUpdatesData {
+  allEntryUpdates: {
+    nodes: {
+      contractId: string;
+      nodeId: string;
+      id: string;
+    }[];
+  };
+}
+
 interface TokenDetails {
   [k: string]: {
     name: string;
@@ -33,4 +43,10 @@ const transformAccountBalances = async (
   });
 };
 
-export { transformAccountBalances };
+const transformEntryUpdates = async (
+  rawResponse: OperationResult<MercuryAllEntryUpdatesData>
+) => {
+  return rawResponse?.data?.allEntryUpdates.nodes.map((node) => node);
+};
+
+export { transformAccountBalances, transformEntryUpdates };

--- a/src/service/mercury/helpers/transformers.ts
+++ b/src/service/mercury/helpers/transformers.ts
@@ -1,0 +1,36 @@
+import { OperationResult } from "@urql/core";
+
+// Transformers take an API response, and transform it/augment it for frontend consumption
+
+interface MercuryAccountBalancesData {
+  entryUpdateByContractIdAndKey: {
+    nodes: {
+      contractId: string;
+      keyXdr: string;
+      valueXdr: string;
+    }[];
+  };
+}
+
+interface TokenDetails {
+  [k: string]: {
+    name: string;
+    symbol: string;
+    decimals: string;
+  };
+}
+
+const transformAccountBalances = async (
+  rawResponse: OperationResult<MercuryAccountBalancesData>,
+  tokenDetails: TokenDetails
+) => {
+  return rawResponse?.data?.entryUpdateByContractIdAndKey.nodes.map((entry) => {
+    const details = tokenDetails[entry.contractId];
+    return {
+      ...entry,
+      ...details,
+    };
+  });
+};
+
+export { transformAccountBalances };

--- a/src/service/mercury/helpers/transformers.ts
+++ b/src/service/mercury/helpers/transformers.ts
@@ -12,16 +12,6 @@ interface MercuryAccountBalancesData {
   };
 }
 
-interface MercuryAllEntryUpdatesData {
-  allEntryUpdates: {
-    nodes: {
-      contractId: string;
-      nodeId: string;
-      id: string;
-    }[];
-  };
-}
-
 interface TokenDetails {
   [k: string]: {
     name: string;

--- a/src/service/mercury/helpers/transformers.ts
+++ b/src/service/mercury/helpers/transformers.ts
@@ -43,10 +43,4 @@ const transformAccountBalances = async (
   });
 };
 
-const transformEntryUpdates = async (
-  rawResponse: OperationResult<MercuryAllEntryUpdatesData>
-) => {
-  return rawResponse?.data?.allEntryUpdates.nodes.map((node) => node);
-};
-
-export { transformAccountBalances, transformEntryUpdates };
+export { transformAccountBalances };

--- a/src/service/mercury/index.test.ts
+++ b/src/service/mercury/index.test.ts
@@ -39,14 +39,13 @@ describe("Mercury Service", () => {
       "CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP",
       "CBGTG7XFRY3L6OKAUTR6KGDKUXUQBX3YDJ3QFDYTGVMOM7VV4O7NCODG",
     ];
-    const { data } = await mockMercuryClient.getAccountBalances(
+    const data = await mockMercuryClient.getAccountBalances(
       pubKey,
-      contracts
+      contracts,
+      "TESTNET"
     );
     expect(
-      data?.data.edges.map(
-        (node: { node: Record<string, string> }) => node.node.contractId
-      )
+      data?.data?.map((node: { contractId: string }) => node.contractId)
     ).toEqual(contracts);
   });
 

--- a/src/service/mercury/index.ts
+++ b/src/service/mercury/index.ts
@@ -287,55 +287,6 @@ export class MercuryClient {
     }
   };
 
-  deleteTokenSubscription = async (contractId: string) => {
-    // get all entry update subs, find ones that match contractId, delete by ID.
-    try {
-      const getData = async () => {
-        const response = await this.urqlClient.query(
-          query.getAllEntryUpdates,
-          {}
-        );
-        const errorMessage = getGraphQlError(response.error);
-        if (errorMessage) {
-          throw new Error(errorMessage);
-        }
-
-        return response;
-      };
-      const response = await this.renewAndRetry(getData);
-      const data = await transformEntryUpdates(response);
-      const match = data?.filter((d) => d.contractId === contractId);
-
-      let deleted = false;
-      if (match) {
-        const response = await this.urqlClient.mutation(
-          mutation.deleteEntryUpdateById,
-          { contractId }
-        );
-        const errorMessage = getGraphQlError(response.error);
-        if (errorMessage) {
-          throw new Error(errorMessage);
-        }
-        deleted = response.error !== undefined;
-      }
-
-      return {
-        data: {
-          contractId,
-          deleted,
-        },
-        error: null,
-      };
-    } catch (error) {
-      const _error = JSON.stringify(error);
-      this.logger.error(error);
-      return {
-        data: null,
-        error: _error,
-      };
-    }
-  };
-
   tokenDetails = async (
     pubKey: string,
     contractId: string,

--- a/src/service/mercury/index.ts
+++ b/src/service/mercury/index.ts
@@ -12,10 +12,7 @@ import {
   getTokenSymbol,
   getTxBuilder,
 } from "../../helper/soroban-rpc";
-import {
-  transformAccountBalances,
-  transformEntryUpdates,
-} from "./helpers/transformers";
+import { transformAccountBalances } from "./helpers/transformers";
 
 type NetworkNames = keyof typeof Networks;
 

--- a/src/service/mercury/queries.ts
+++ b/src/service/mercury/queries.ts
@@ -473,15 +473,4 @@ export const query = {
 
     }
   `,
-  getAllEntryUpdates: `
-    query GetAllEntryUpdates {
-      allEntryUpdates {
-        nodes {
-          contractId
-          nodeId
-          id
-        }
-      }
-    }
-  `,
 };

--- a/src/service/mercury/queries.ts
+++ b/src/service/mercury/queries.ts
@@ -18,13 +18,6 @@ export const mutation = {
       }
     }
   `,
-  deleteEntryUpdateById: `
-    mutation DeletEntryById($contractId: String!) {
-      deleteEntryUpdateById(input: {id: $contractId}) {
-        deletedEntryUpdateId
-      }
-    }
-  `,
 };
 export const query = {
   allSubscriptions: `

--- a/src/service/mercury/queries.ts
+++ b/src/service/mercury/queries.ts
@@ -18,6 +18,13 @@ export const mutation = {
       }
     }
   `,
+  deleteEntryUpdateById: `
+    mutation DeletEntryById($contractId: String!) {
+      deleteEntryUpdateById(input: {id: $contractId}) {
+        deletedEntryUpdateId
+      }
+    }
+  `,
 };
 export const query = {
   allSubscriptions: `
@@ -471,6 +478,17 @@ export const query = {
         }
       }
 
+    }
+  `,
+  getAllEntryUpdates: `
+    query GetAllEntryUpdates {
+      allEntryUpdates {
+        nodes {
+          contractId
+          nodeId
+          id
+        }
+      }
     }
   `,
 };


### PR DESCRIPTION
Adds a Redis workflow for storing/getting token details which are immutable once set. When a subscription is added, we attempt to fetch and store token details in Redis for faster access in subsequent queries. The new `tokenDetails` will return cached token details when found, otherwise will look them up on the ledger and cache them.

Adds first `transformer`, transformers are a type of helper that take Mercury responses(and sometimes other data) and transforms it into the desired response for the API route.