### PR TITLE
adds options for custom rpc urls

### DIFF
--- a/src/helper/soroban-rpc.ts
+++ b/src/helper/soroban-rpc.ts
@@ -18,8 +18,10 @@ const SOROBAN_RPC_URLS: { [key in keyof typeof Networks]?: string } = {
   TESTNET: "https://soroban-testnet.stellar.org/",
 };
 
-const getServer = async (network: NetworkNames) => {
-  const serverUrl = SOROBAN_RPC_URLS[network];
+const getServer = async (network: NetworkNames, customRpcUrl?: string) => {
+  const serverUrl = !SOROBAN_RPC_URLS[network]
+    ? customRpcUrl
+    : SOROBAN_RPC_URLS[network];
   if (!serverUrl) {
     throw new Error("network not supported");
   }

--- a/src/route/index.ts
+++ b/src/route/index.ts
@@ -58,20 +58,31 @@ export function initApiServer(
               type: "string",
               validator: (qStr: string) => isNetwork(qStr),
             },
+            ["horizon_url"]: {
+              type: "string",
+            },
+            ["soroban_url"]: {
+              type: "string",
+            },
           },
         },
         handler: async (
           request: FastifyRequest<{
             Params: { ["pubKey"]: string };
-            Querystring: { ["network"]: NetworkNames };
+            Querystring: {
+              ["network"]: NetworkNames;
+              ["horizon_url"]?: string;
+              ["soroban_url"]?: string;
+            };
           }>,
           reply
         ) => {
           const pubKey = request.params["pubKey"];
-          const network = request.query["network"];
+          const { network, horizon_url, soroban_url } = request.query;
           const { data, error } = await mercuryClient.getAccountHistory(
             pubKey,
-            network
+            network,
+            { horizon: horizon_url, soroban: soroban_url }
           );
           if (error) {
             reply.code(400).send(error);
@@ -100,6 +111,12 @@ export function initApiServer(
               type: "string",
               validator: (qStr: string) => isNetwork(qStr),
             },
+            ["horizon_url"]: {
+              type: "string",
+            },
+            ["soroban_url"]: {
+              type: "string",
+            },
           },
         },
         handler: async (
@@ -108,19 +125,22 @@ export function initApiServer(
             Querystring: {
               ["contract_ids"]: string;
               ["network"]: NetworkNames;
+              ["horizon_url"]?: string;
+              ["soroban_url"]?: string;
             };
           }>,
           reply
         ) => {
           const pubKey = request.params["pubKey"];
-          const network = request.query["network"];
+          const { network, horizon_url, soroban_url } = request.query;
           const contractIds = request.query["contract_ids"]
             ? request.query["contract_ids"].split(",")
             : [];
           const { data, error } = await mercuryClient.getAccountBalances(
             pubKey,
             contractIds,
-            network
+            network,
+            { horizon: horizon_url, soroban: soroban_url }
           );
           if (error) {
             reply.code(400).send(error);

--- a/src/service/mercury/index.test.ts
+++ b/src/service/mercury/index.test.ts
@@ -12,7 +12,8 @@ describe("Mercury Service", () => {
   it("can fetch account history with a payment-to in history", async () => {
     const { data } = await mockMercuryClient.getAccountHistory(
       pubKey,
-      "TESTNET"
+      "TESTNET",
+      {}
     );
     const payment = data.data?.find((d) => {
       if ("asset_code" in d && d.asset_code === "DT") {
@@ -43,7 +44,8 @@ describe("Mercury Service", () => {
     const { data } = await mockMercuryClient.getAccountBalances(
       pubKey,
       contracts,
-      "TESTNET"
+      "TESTNET",
+      {}
     );
     const tokenDetails = {
       CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP: {


### PR DESCRIPTION
Ticket: https://stellarorg.atlassian.net/jira/software/c/projects/WAL/boards/36?assignee=63bc81730a1b5442166a2f79&selectedIssue=WAL-1212

In order to support custom networks in Freighter, we need to be able to optionally pass RPC URLs to be used for account balances and account history.

This adds optional query params on both routes to provide those, and updates the service to attempt to use those URLs in the case that we don't have a match for natively supported URLs.