### PR TITLE
adds route and helper to submit transaction to the horizon rpc

### DIFF
--- a/src/route/index.ts
+++ b/src/route/index.ts
@@ -292,14 +292,6 @@ export function initApiServer(
               network_passphrase: { type: "string" },
             },
           },
-          response: {
-            200: {
-              type: "object",
-              properties: {
-                data: { type: "object" },
-              },
-            },
-          },
         },
         handler: async (
           request: FastifyRequest<{

--- a/src/route/index.ts
+++ b/src/route/index.ts
@@ -161,6 +161,58 @@ export function initApiServer(
       });
 
       instance.route({
+        method: "GET",
+        url: "/token-details/:contractId",
+        schema: {
+          params: {
+            ["contractId"]: {
+              type: "string",
+              validator: (qStr: string) => isContractId(qStr),
+            },
+          },
+          querystring: {
+            ["pub_key"]: {
+              type: "string",
+              validator: (qStr: string) => isPubKey(qStr),
+            },
+            ["network"]: {
+              type: "string",
+              validator: (qStr: string) => isNetwork(qStr),
+            },
+            ["soroban_url"]: {
+              type: "string",
+            },
+          },
+        },
+        handler: async (
+          request: FastifyRequest<{
+            Params: { ["contractId"]: string };
+            Querystring: {
+              ["contract_ids"]: string;
+              ["pub_key"]: string;
+              ["network"]: NetworkNames;
+              ["soroban_url"]?: string;
+            };
+          }>,
+          reply
+        ) => {
+          const contractId = request.params["contractId"];
+          const { network, pub_key, soroban_url } = request.query;
+          try {
+            const data = await mercuryClient.tokenDetails(
+              pub_key,
+              contractId,
+              network,
+              soroban_url
+            );
+            reply.code(200).send(data);
+          } catch (error) {
+            reply.code(400).send(error);
+          }
+        },
+      });
+
+      instance.route({
         method: "POST",
         url: "/subscription/token",
         schema: {

--- a/src/route/index.ts
+++ b/src/route/index.ts
@@ -12,6 +12,7 @@ import {
   isNetwork,
   NetworkNames,
 } from "../helper/validate";
+import { submitTransaction } from "../helper/horizon-rpc";
 
 const API_VERSION = "v1";
 
@@ -250,6 +251,51 @@ export function initApiServer(
             contract_id,
             pub_key,
             network
+          );
+          if (error) {
+            reply.code(400).send(error);
+          } else {
+            reply.code(200).send(data);
+          }
+        },
+      });
+
+      instance.route({
+        method: "POST",
+        url: "/submit-tx",
+        schema: {
+          body: {
+            type: "object",
+            properties: {
+              signed_xdr: { type: "string" },
+              network_url: { type: "string" },
+              network_passphrase: { type: "string" },
+            },
+          },
+          response: {
+            200: {
+              type: "object",
+              properties: {
+                data: { type: "object" },
+              },
+            },
+          },
+        },
+        handler: async (
+          request: FastifyRequest<{
+            Body: {
+              signed_xdr: string;
+              network_url: string;
+              network_passphrase: string;
+            };
+          }>,
+          reply
+        ) => {
+          const { signed_xdr, network_url, network_passphrase } = request.body;
+          const { data, error } = await submitTransaction(
+            signed_xdr,
+            network_url,
+            network_passphrase
           );
           if (error) {
             reply.code(400).send(error);

--- a/src/service/mercury/index.ts
+++ b/src/service/mercury/index.ts
@@ -332,7 +332,8 @@ export class MercuryClient {
   tokenDetails = async (
     pubKey: string,
     contractId: string,
-    network: NetworkNames
+    network: NetworkNames,
+    customRpcUrl?: string
   ): Promise<
     { name: string; symbol: string; decimals: number } | undefined
   > => {
@@ -345,7 +346,7 @@ export class MercuryClient {
           return JSON.parse(tokenDetails);
         }
       }
-      const server = await getServer(network);
+      const server = await getServer(network, customRpcUrl);
       // we need a builder per operation, 1 op per tx in Soroban
       const decimalsBuilder = await getTxBuilder(pubKey, network, server);
       const decimals = await getTokenDecimals(


### PR DESCRIPTION
The platform team would like Freighter to start moving towards a world where it doesn't use the RPCs directly in an effort to move away from promoting the SDF hosted RPCs and to encourage community involvement.

This adds a way to submit transactions to the RPC through a route, submitting transactions to the Horizon RPC should work for Soroban(invoke host fn) ops as well.