### PR TITLE
[FIX] Fallback history for networks that support Horizon but not Soroban RPC

### DIFF
--- a/src/service/mercury/index.ts
+++ b/src/service/mercury/index.ts
@@ -499,20 +499,25 @@ export class MercuryClient {
     network: NetworkNames,
     customSorobanRpcUrl?: string
   ) => {
-    const server = await getServer(network, customSorobanRpcUrl);
     const balances = [];
-    for (const id of contractIds) {
-      const builder = await getTxBuilder(pubKey, network, server);
-      const params = [new Address(pubKey).toScVal()];
-      const balance = await getTokenBalance(id, params, server, builder);
-      const tokenDetails = await this.tokenDetails(pubKey, id, network);
-      balances.push({
-        id,
-        balance,
-        ...tokenDetails,
-      });
-    }
     const balanceMap = {} as Record<string, any>;
+    try {
+      const server = await getServer(network, customSorobanRpcUrl);
+      for (const id of contractIds) {
+        const builder = await getTxBuilder(pubKey, network, server);
+        const params = [new Address(pubKey).toScVal()];
+        const balance = await getTokenBalance(id, params, server, builder);
+        const tokenDetails = await this.tokenDetails(pubKey, id, network);
+        balances.push({
+          id,
+          balance,
+          ...tokenDetails,
+        });
+      }
+    } catch (error) {
+      this.logger.error(error);
+      return balanceMap;
+    }
     for (const balance of balances) {
       balanceMap[`${balance.symbol}:${balance.id}`] = {
         token: {
@@ -677,8 +682,10 @@ export class MercuryClient {
           rpc: "Horizon",
         })
         .inc();
+
+      // Horizon is supported on all networks, return error if Horizon does
       return {
-        data: null,
+        data: classicBalances,
         error,
       };
     }
@@ -700,10 +707,6 @@ export class MercuryClient {
           rpc: "Soroban",
         })
         .inc();
-      return {
-        data: null,
-        error,
-      };
     }
 
     const data = {


### PR DESCRIPTION
Fixes this: https://stellarorg.atlassian.net/browse/WAL-1228 along with https://github.com/stellar/freighter/pull/1077
This fixes an oversight in history for cases where the network supports Horizon but not Soroban RPC.
This is only pubnet and will soon be no networks, expect maybe standalone networks where Soroban RPC is turned off.

I think there's still an open question of what we should do if one of the RPCs errors and the other doesn't, this doesn't seem likely but it's possible. Right now, we try for a composite data/error flow, where we return data from either if we can while logging errors from either but maybe it would be better to surface the errors from either even if we have a successful response from the other and let the client handle how to surface that to the user?