### PR TITLE
add env var toggle to turn off mercury globally

### DIFF
--- a/.env-EXAMPLE
+++ b/.env-EXAMPLE
@@ -8,3 +8,4 @@ REDIS_CONNECTION_NAME=not-set
 REDIS_PORT=not-set
 HOSTNAME=not-set
 MODE=not-set
+USE_MERCURY=not-set

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ const ENV_KEYS = [
   "MODE",
   "REDIS_CONNECTION_NAME",
   "REDIS_PORT",
+  "USE_MERCURY",
 ];
 
 export function buildConfig(config: Record<string, string>) {
@@ -30,6 +31,7 @@ export function buildConfig(config: Record<string, string>) {
     redisConnectionName:
       config.REDIS_CONNECTION_NAME || process.env.REDIS_CONNECTION_NAME!,
     redisPort: Number(config.REDIS_PORT) || Number(process.env.REDIS_PORT!),
+    useMercury: config.USE_MERCURY || process.env.USE_MERCURY!,
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,7 +31,9 @@ export function buildConfig(config: Record<string, string>) {
     redisConnectionName:
       config.REDIS_CONNECTION_NAME || process.env.REDIS_CONNECTION_NAME!,
     redisPort: Number(config.REDIS_PORT) || Number(process.env.REDIS_PORT!),
-    useMercury: config.USE_MERCURY || process.env.USE_MERCURY!,
+    useMercury: Boolean(
+      config.USE_MERCURY || process.env.USE_MERCURY! || false
+    ),
   };
 }
 

--- a/src/helper/test-helper.ts
+++ b/src/helper/test-helper.ts
@@ -278,7 +278,7 @@ jest
     }
   );
 async function getDevServer() {
-  const server = initApiServer(mockMercuryClient, testLogger, register);
+  const server = initApiServer(mockMercuryClient, testLogger, register, true);
   await server.listen();
   return server;
 }

--- a/src/helper/test-helper.ts
+++ b/src/helper/test-helper.ts
@@ -278,7 +278,12 @@ jest
     }
   );
 async function getDevServer() {
-  const server = initApiServer(mockMercuryClient, testLogger, register, true);
+  const server = await initApiServer(
+    mockMercuryClient,
+    testLogger,
+    register,
+    true
+  );
 
   await server.listen();
   return server;

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,13 @@ async function main() {
     register,
     redis
   );
-  const server = initApiServer(mercuryClient, logger, register, redis);
+  const server = initApiServer(
+    mercuryClient,
+    logger,
+    register,
+    conf.useMercury,
+    redis
+  );
 
   try {
     await server.listen({ port, host: "0.0.0.0" });

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ async function main() {
     register,
     redis
   );
-  const server = initApiServer(
+  const server = await initApiServer(
     mercuryClient,
     logger,
     register,

--- a/src/route/index.ts
+++ b/src/route/index.ts
@@ -32,6 +32,7 @@ export function initApiServer(
   mercuryClient: MercuryClient,
   logger: Logger,
   register: Prometheus.Registry,
+  useMercury: boolean,
   redis?: Redis
 ) {
   const server = Fastify({
@@ -105,7 +106,8 @@ export function initApiServer(
           const { data, error } = await mercuryClient.getAccountHistory(
             pubKey,
             network,
-            { horizon: horizon_url, soroban: soroban_url }
+            { horizon: horizon_url, soroban: soroban_url },
+            useMercury
           );
           if (error) {
             reply.code(400).send(error);
@@ -163,7 +165,8 @@ export function initApiServer(
             pubKey,
             contractIds,
             network,
-            { horizon: horizon_url, soroban: soroban_url }
+            { horizon: horizon_url, soroban: soroban_url },
+            useMercury
           );
           if (error) {
             reply.code(400).send(error);
@@ -211,6 +214,11 @@ export function initApiServer(
         ) => {
           const contractId = request.params["contractId"];
           const { network, pub_key, soroban_url } = request.query;
+
+          if (!useMercury) {
+            reply.code(400).send("Mercury disabled");
+          }
+
           try {
             const data = await mercuryClient.tokenDetails(
               pub_key,
@@ -257,6 +265,11 @@ export function initApiServer(
           reply
         ) => {
           const { contract_id, pub_key, network } = request.body;
+
+          if (!useMercury) {
+            reply.code(400).send("Mercury disabled");
+          }
+
           const { data, error } = await mercuryClient.tokenSubscription(
             contract_id,
             pub_key,
@@ -297,6 +310,11 @@ export function initApiServer(
           reply
         ) => {
           const { pub_key, network } = request.body;
+
+          if (!useMercury) {
+            reply.code(400).send("Mercury disabled");
+          }
+
           const { data, error } = await mercuryClient.accountSubscription(
             pub_key,
             network
@@ -341,6 +359,11 @@ export function initApiServer(
           reply
         ) => {
           const { pub_key, contract_id, network } = request.body;
+
+          if (!useMercury) {
+            reply.code(400).send("Mercury disabled");
+          }
+
           const { data, error } = await mercuryClient.tokenBalanceSubscription(
             contract_id,
             pub_key,

--- a/src/service/mercury/index.test.ts
+++ b/src/service/mercury/index.test.ts
@@ -13,7 +13,8 @@ describe("Mercury Service", () => {
     const { data } = await mockMercuryClient.getAccountHistory(
       pubKey,
       "TESTNET",
-      {}
+      {},
+      true
     );
     const payment = (data || []).find((d) => {
       if ("asset_code" in d && d.asset_code === "DT") {
@@ -45,7 +46,8 @@ describe("Mercury Service", () => {
       pubKey,
       contracts,
       "TESTNET",
-      {}
+      {},
+      true
     );
     const tokenDetails = {
       CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP: {

--- a/src/service/mercury/index.ts
+++ b/src/service/mercury/index.ts
@@ -468,9 +468,10 @@ export class MercuryClient {
   getAccountHistory = async (
     pubKey: string,
     network: NetworkNames,
-    rpcUrls: { horizon?: string; soroban?: string }
+    rpcUrls: { horizon?: string; soroban?: string },
+    useMercury: boolean
   ) => {
-    if (hasIndexerSupport(network)) {
+    if (hasIndexerSupport(network) && useMercury) {
       const response = await this.getAccountHistoryMercury(pubKey);
 
       if (!response.error) {
@@ -633,9 +634,10 @@ export class MercuryClient {
     pubKey: string,
     contractIds: string[],
     network: NetworkNames,
-    rpcUrls: { horizon?: string; soroban?: string }
+    rpcUrls: { horizon?: string; soroban?: string },
+    useMercury: boolean
   ) => {
-    if (hasIndexerSupport(network)) {
+    if (hasIndexerSupport(network) && useMercury) {
       const response = await this.getAccountBalancesMercury(
         pubKey,
         contractIds,


### PR DESCRIPTION
This will allow us to toggle Mercury off globally if needed, initially to be prepared for the deployment to prd in the case that we are not ready on the Mercury side.