### PR TITLE
tweaks the response for invoke host fns to expose fn name and args

### DIFF
--- a/src/service/mercury/queries.ts
+++ b/src/service/mercury/queries.ts
@@ -58,9 +58,17 @@ export const query = {
             contractId
             keyXdr
             valueXdr
-            ledgerTimestamp
-            ledger
             entryDurability
+            txInfoByTx {
+              fee
+              opCount
+              txHash
+              ledger
+              ledgerByLedger {
+                closeTime
+                sequence
+              }
+            }
           }
         }
         `
@@ -68,14 +76,16 @@ export const query = {
     }
   `,
   getAccountHistory: `
-    query GetAccountHistory($pubKey: String!, $xdrPubKey: String!) {
+    query GetAccountHistory($pubKey: String!) {
       invokeHostFnByPublicKey(publicKeyText: $pubKey) {
         edges {
           node {
             auth
             hostFunction
             sorobanMeta
-            source
+            accountBySource {
+              publickey
+            }
             tx
             opId
             txInfoByTx {


### PR DESCRIPTION
Tweaks the history response for a Mercury change, pulling the fn args/name from the HostFunction instead of expecting an tx_envelope.
Tweaks the metrics reporter for Horizon calls to avoid alerting on NotFound errors.