### PR TITLE
[BUG] fixes dropped metrics data

### DIFF
--- a/src/route/metrics.ts
+++ b/src/route/metrics.ts
@@ -27,7 +27,8 @@ export async function initMetricsServer(
       url: "/metrics",
       handler: async (_request, reply) => {
         reply.header("Content-Type", register.contentType);
-        register.metrics().then((data) => reply.code(200).send(data));
+        const data = await register.metrics();
+        reply.code(200).send(data);
       },
     });
     next();


### PR DESCRIPTION
This was previously not returning the metrics data, but an empty success response.