### PR TITLE
adds a route to pass through rpc health

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -33,7 +33,7 @@ export function buildConfig(config: Record<string, string>) {
     redisPort: Number(config.REDIS_PORT) || Number(process.env.REDIS_PORT!),
     useMercury:
       config.USE_MERCURY === "true" || process.env.USE_MERCURY === "true",
-    useSorobanPublic: true,
+    useSorobanPublic: false,
   };
 }
 


### PR DESCRIPTION
Passes through `server.getHealth` so that we can check on rpc connection status from a route.