### PR TITLE
Feat/add contract

### DIFF
--- a/src/helper/error.ts
+++ b/src/helper/error.ts
@@ -3,4 +3,5 @@ export const ERROR = {
     "Transfer contains authorization entry for a different account",
   AUTH_SUB_INVOCATIONS:
     "Transfer authorizes sub-invocations to another contract",
+  FAILED_TO_SIM: "Failed to simulate transaction",
 };

--- a/src/service/mercury/index.ts
+++ b/src/service/mercury/index.ts
@@ -560,6 +560,7 @@ export class MercuryClient {
           },
         },
         contractId: balance.id,
+        symbol: balance.symbol,
         decimals: balance.decimals,
         total: new BigNumber(balance.balance),
         available: new BigNumber(balance.balance),

--- a/src/service/mercury/index.ts
+++ b/src/service/mercury/index.ts
@@ -25,6 +25,7 @@ import {
   fetchAccountHistory,
 } from "../../helper/horizon-rpc";
 import { NetworkNames } from "../../helper/validate";
+import { ERROR } from "../../helper/error";
 
 enum NETWORK_URLS {
   PUBLIC = "https://horizon.stellar.org",
@@ -407,7 +408,7 @@ export class MercuryClient {
       };
     } catch (error) {
       this.logger.error(error);
-      return;
+      throw ERROR.FAILED_TO_SIM;
     }
   };
 
@@ -558,6 +559,7 @@ export class MercuryClient {
             key: balance.id,
           },
         },
+        contractId: balance.id,
         decimals: balance.decimals,
         total: new BigNumber(balance.balance),
         available: new BigNumber(balance.balance),


### PR DESCRIPTION
Adds back contractId and symbol in order to make the pattern for standalone easier to use with the backend schema.
Unrelated: passes through fail to simulate errors for better error response in simulation route.