### PR TITLE
[FEATURE] Feature/new routes health and generic message

### DIFF
--- a/src/helper/horizon-rpc.ts
+++ b/src/helper/horizon-rpc.ts
@@ -5,6 +5,14 @@ export const BASE_RESERVE = 0.5;
 export const BASE_RESERVE_MIN_COUNT = 2;
 const TRANSACTIONS_LIMIT = 100;
 
+export enum NETWORK_URLS {
+  PUBLIC = "https://horizon.stellar.org",
+  TESTNET = "https://horizon-testnet.stellar.org",
+  FUTURENET = "https://horizon-futurenet.stellar.org",
+  SANDBOX = "",
+  STANDALONE = "",
+}
+
 export interface Issuer {
   key: string;
   name?: string;

--- a/src/route/index.ts
+++ b/src/route/index.ts
@@ -18,7 +18,6 @@ import { NETWORK_URLS, submitTransaction } from "../helper/horizon-rpc";
 import {
   Address,
   BASE_FEE,
-  Horizon,
   Memo,
   MemoType,
   Operation,
@@ -178,13 +177,11 @@ export async function initApiServer(
             console.log(health.data);
             reply.code(200).send(health.data);
           } catch (error) {
-            reply
-              .code(500)
-              .send({
-                database_connected: null,
-                core_up: null,
-                core_synced: null,
-              });
+            reply.code(500).send({
+              database_connected: null,
+              core_up: null,
+              core_synced: null,
+            });
           }
         },
       });

--- a/src/service/mercury/index.ts
+++ b/src/service/mercury/index.ts
@@ -23,17 +23,10 @@ import {
 import {
   fetchAccountDetails,
   fetchAccountHistory,
+  NETWORK_URLS,
 } from "../../helper/horizon-rpc";
 import { NetworkNames } from "../../helper/validate";
 import { ERROR } from "../../helper/error";
-
-enum NETWORK_URLS {
-  PUBLIC = "https://horizon.stellar.org",
-  TESTNET = "https://horizon-testnet.stellar.org",
-  FUTURENET = "https://horizon-futurenet.stellar.org",
-  SANDBOX = "",
-  STANDALONE = "",
-}
 
 const ERROR_MESSAGES = {
   JWT_EXPIRED: "1_kJdMBB7ytvgRIqF1clh2iz2iI",


### PR DESCRIPTION
What
Adds 2 new route -
`/user-subscription`
`/horizon-health`

Why
`/user-subscription`
This route will be used to trigger generic notification to show in the UI. Since the deployment lifecycle for the backend is much faster than the client, we can use this as an mvp notification system by deploying a change that toggles the `enabled` flag to true, and sets a string to be displayed in the UI.

`/horizon-health`
This route will be used in order to trigger a Horizon related degradation notice. Notable the Horizon health endpoint is different from the rpc one in that the rpc one looks to be about describing the health of the rpc itself and the Horizon one looks to be used to provide health checks for it's dependencies like it;s database and core instance. The response looks like this 
`{"database_connected":true,"core_up":true,"core_synced":true}`
I think it's worth considering if we want to trigger the notification on error conditions from calls to the Horizon API instead or additionally to using this as a signal to Horizon being unhealthy.
