### PR TITLE
[FIX] pass simulation failures as error message in route response

### DIFF
--- a/src/helper/soroban-rpc.ts
+++ b/src/helper/soroban-rpc.ts
@@ -51,11 +51,15 @@ const simulateTx = async <ArgType>(
   server: SorobanRpc.Server
 ): Promise<ArgType> => {
   const simulatedTX = await server.simulateTransaction(tx);
-  if ("result" in simulatedTX && simulatedTX.result !== undefined) {
+  if (SorobanRpc.Api.isSimulationSuccess(simulatedTX) && simulatedTX.result) {
     return scValToNative(simulatedTX.result.retval);
   }
 
-  throw new Error(ERROR.INVALID_SIMULATION);
+  if (SorobanRpc.Api.isSimulationError(simulatedTX)) {
+    throw new Error(simulatedTX.error);
+  }
+
+  throw new Error(ERROR.FAILED_TO_SIM);
 };
 
 const getTokenDecimals = async (

--- a/src/route/index.ts
+++ b/src/route/index.ts
@@ -354,7 +354,7 @@ export async function initApiServer(
             );
             reply.code(200).send(data);
           } catch (error) {
-            reply.code(400).send(JSON.stringify(error));
+            reply.code(400).send(error);
           }
         },
       });

--- a/src/service/mercury/index.ts
+++ b/src/service/mercury/index.ts
@@ -392,8 +392,10 @@ export class MercuryClient {
         symbol,
       };
     } catch (error) {
-      this.logger.error(error);
-      throw ERROR.FAILED_TO_SIM;
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error(JSON.stringify(error));
     }
   };
 


### PR DESCRIPTION
What
Passes simulation failures through to the caller, and returns those in the route response error case for token-details

Why
Errors from token-details were not very helpful for clients, didn't expose failure reasons