### PR TITLE
[FEATURE] Check subscription before query

### DIFF
--- a/src/helper/error.ts
+++ b/src/helper/error.ts
@@ -10,4 +10,6 @@ export const ERROR = {
   INVALID_VALIDATOR_DEF: "Invalid definition for custom validator",
   TOKEN_SUB_FAILED: "Failed to subscribe to token events",
   SERVER_ERROR: "Unexpected server error",
+  MISSING_SUB_FOR_PUBKEY:
+    "Tried to query for data without a subscription setup for a public key",
 };

--- a/src/helper/mercury.ts
+++ b/src/helper/mercury.ts
@@ -8,3 +8,8 @@ export enum MercurySupportedNetworks {
   TESTNET = "TESTNET",
   PUBLIC = "PUBLIC",
 }
+
+export const hasSubForPublicKey = (
+  subs: { publickey: string }[],
+  publicKey: string
+) => subs.some((sub: { publickey: string }) => sub.publickey === publicKey);

--- a/src/helper/test-helper.ts
+++ b/src/helper/test-helper.ts
@@ -90,6 +90,14 @@ function backendClientMaker(network: NetworkNames) {
           error: null,
         });
       }
+      case query.getAccountSubForPubKey(pubKey): {
+        return Promise.resolve({
+          data: {
+            allFullAccountSubscriptionsList: [{ publickey: pubKey }],
+          },
+          error: null,
+        });
+      }
       default:
         throw new Error("unknown query in mock");
     }

--- a/src/service/mercury/helpers/transformers.ts
+++ b/src/service/mercury/helpers/transformers.ts
@@ -131,8 +131,8 @@ const transformAccountBalances = async (
           key: curr.assetByAsset.issuer,
         },
       },
-      total: new BigNumber(curr.balance),
-      available: new BigNumber(curr.balance),
+      total: formatTokenAmount(new BigNumber(curr.balance), 7),
+      available: formatTokenAmount(new BigNumber(curr.balance), 7),
     };
     return prev;
   }, {} as NonNullable<AccountBalancesInterface["balances"]>);

--- a/src/service/mercury/index.test.ts
+++ b/src/service/mercury/index.test.ts
@@ -84,4 +84,29 @@ describe("Mercury Service", () => {
       queryMockResponse[mutation.authenticate].authenticate?.jwtToken
     );
   });
+
+  it("getAccountBalancesMercury throws when there is no sub for public key", async () => {
+    jest
+      .spyOn(mockMercuryClient, "getAccountSubForPubKey")
+      .mockImplementation(
+        (
+          ..._args: Parameters<typeof mockMercuryClient.getAccountSubForPubKey>
+        ): ReturnType<typeof mockMercuryClient.getAccountSubForPubKey> => {
+          return Promise.resolve([{ publickey: "nope" }]);
+        }
+      );
+
+    const response = await mockMercuryClient.getAccountBalancesMercury(
+      pubKey,
+      [],
+      "TESTNET"
+    );
+    expect(response).toHaveProperty("error");
+    expect(response.error).toBeInstanceOf(Error);
+    if (response.error instanceof Error) {
+      expect(response.error.message).toContain(
+        "Tried to query for data without a subscription setup for a public key"
+      );
+    }
+  });
 });

--- a/src/service/mercury/index.test.ts
+++ b/src/service/mercury/index.test.ts
@@ -64,7 +64,7 @@ describe("Mercury Service", () => {
       tokenDetails as any
     );
     const expected = {
-      data: transformedData,
+      ...transformedData,
       error: {
         horizon: null,
         soroban: null,

--- a/src/service/mercury/index.ts
+++ b/src/service/mercury/index.ts
@@ -643,9 +643,12 @@ export class MercuryClient {
       );
 
       // if Mercury returns an error, fallback to the RPCs
-      if (!response.error) {
+      if (!response.error && response.data) {
+        const { balances, isFunded, subentryCount } = response.data;
         return {
-          data: response.data,
+          balances,
+          isFunded,
+          subentryCount,
           error: {
             horizon: null,
             soroban: null,

--- a/src/service/mercury/index.ts
+++ b/src/service/mercury/index.ts
@@ -32,6 +32,7 @@ import { ERROR } from "../../helper/error";
 import {
   MercurySupportedNetworks,
   hasIndexerSupport,
+  hasSubForPublicKey,
 } from "../../helper/mercury";
 
 const ERROR_MESSAGES = {
@@ -438,10 +439,8 @@ export class MercuryClient {
         throw new Error(`network not currently supported: ${network}`);
       }
       const subs = await this.getAccountSubForPubKey(pubKey, network);
-      const hasSubForPublicKey = subs.some(
-        (sub: { publickey: string }) => sub.publickey === pubKey
-      );
-      if (!hasSubForPublicKey) {
+      const hasSubs = hasSubForPublicKey(subs, pubKey);
+      if (!hasSubs) {
         throw new Error(ERROR.MISSING_SUB_FOR_PUBKEY);
       }
 
@@ -596,10 +595,8 @@ export class MercuryClient {
         throw new Error(`network not currently supported: ${network}`);
       }
       const subs = await this.getAccountSubForPubKey(pubKey, network);
-      const hasSubForPublicKey = subs.some(
-        (sub: { publickey: string }) => sub.publickey === pubKey
-      );
-      if (!hasSubForPublicKey) {
+      const hasSubs = hasSubForPublicKey(subs, pubKey);
+      if (!hasSubs) {
         throw new Error(ERROR.MISSING_SUB_FOR_PUBKEY);
       }
 

--- a/src/service/mercury/queries.ts
+++ b/src/service/mercury/queries.ts
@@ -19,6 +19,13 @@ export const query = {
       }
     }
   `,
+  getAccountSubForPubKey: (pubKey: string) => `
+    query AccountSub {
+      allFullAccountSubscriptionsList(first:10, offset:0, condition: { publickey: "${pubKey}" }) {
+        publickey
+      }
+    }
+  `,
   getAccountBalances: (
     pubKey: string,
     ledgerKey: string,


### PR DESCRIPTION
What
Adds `getAccountSubForPubKey` that checks if a public key has an account subscription in Mercury.
Uses this check in `getAccountHistoryMercury` & `getAccountBalancesMercury`

Why
To guard us against failed subscriptions or otherwise missing subscriptions for account that we try to query Mercury for, falls back to RPCs if the public key has no account subscription.