### PR TITLE
fixes check in config to not reject on unknown keys

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -13,11 +13,19 @@ const ENV_KEYS = [
 ];
 
 export function buildConfig(config: Record<string, string>) {
-  Object.keys(config).forEach((key) => {
-    if (!ENV_KEYS.includes(key)) {
-      throw new Error(ERROR.INVALID_ENV(key));
+  const configKeys = Object.keys(config);
+  const missingKeys = [] as string[];
+
+  const isMissingKeys = ENV_KEYS.every((key) => {
+    if (configKeys.includes(key)) {
+      return true;
     }
+    missingKeys.push(key);
+    return false;
   });
+  if (!isMissingKeys) {
+    throw new Error(ERROR.INVALID_ENV(missingKeys.join()));
+  }
 
   return {
     hostname: config.HOSTNAME || process.env.HOSTNAME!,


### PR DESCRIPTION
What
Refactors the config env variable check to not reject unknown keys, and to reject on missing ones

Why
This was previously rejecting unknown keys which is not needed since we will ignore them anyways, and that behavior will crash the server if we ever remove an env var and dont remove it in our infra setup.