### PR TITLE
[FEATURE] Retry on non 401 subscription errors

### DIFF
--- a/src/service/mercury/index.test.ts
+++ b/src/service/mercury/index.test.ts
@@ -9,7 +9,7 @@ import {
 import { transformAccountBalances } from "./helpers/transformers";
 import { ERROR_MESSAGES } from ".";
 
-describe.only("Mercury Service", () => {
+describe("Mercury Service", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });

--- a/src/service/mercury/index.ts
+++ b/src/service/mercury/index.ts
@@ -35,6 +35,8 @@ import {
   hasSubForPublicKey,
 } from "../../helper/mercury";
 
+const DEFAULT_RETRY_AMOUNT = 5;
+
 export const ERROR_MESSAGES = {
   JWT_EXPIRED: "1_kJdMBB7ytvgRIqF1clh2iz2iI",
 };
@@ -241,7 +243,7 @@ export class MercuryClient {
       };
 
       const { transferFromRes, transferToRes, mintRes } =
-        await this.renewAndRetry(subscribe, network, 5);
+        await this.renewAndRetry(subscribe, network, DEFAULT_RETRY_AMOUNT);
 
       if (!transferFromRes || !transferToRes || !mintRes) {
         throw new Error(ERROR.TOKEN_SUB_FAILED);
@@ -286,7 +288,11 @@ export class MercuryClient {
         return data;
       };
 
-      const data = await this.renewAndRetry(subscribe, network, 5);
+      const data = await this.renewAndRetry(
+        subscribe,
+        network,
+        DEFAULT_RETRY_AMOUNT
+      );
 
       return {
         data,
@@ -326,7 +332,11 @@ export class MercuryClient {
         const { data } = await axios.post(entryUrl, entrySub, config);
         return data;
       };
-      const data = await this.renewAndRetry(getData, network, 5);
+      const data = await this.renewAndRetry(
+        getData,
+        network,
+        DEFAULT_RETRY_AMOUNT
+      );
 
       if (this.redisClient) {
         await this.tokenDetails(pubKey, contractId, network);


### PR DESCRIPTION
What
Adds `retryCount` optional param to `renewAndRetry`. This allows callers to add a number of retries to do in case of a non 401 error response.
Uses `retryCount` in subscriptions to retry failure cases.
Refactors and adds tests for `renewAndRetry`.

Why
In the edge case that we fail a subscription, we should retry a low number of times in order to guard against transient errors.