### PR TITLE
[FEATURE] Add subscription when missing in GET

### DIFF
--- a/src/service/mercury/index.ts
+++ b/src/service/mercury/index.ts
@@ -480,6 +480,12 @@ export class MercuryClient {
       const subs = await this.getAccountSubForPubKey(pubKey, network);
       const hasSubs = hasSubForPublicKey(subs, pubKey);
       if (!hasSubs) {
+        const { error } = await this.accountSubscription(pubKey, network);
+        if (!error) {
+          this.logger.info(
+            `Subscribed to missing account sub - ${pubKey} - ${network}`
+          );
+        }
         throw new Error(ERROR.MISSING_SUB_FOR_PUBKEY);
       }
 
@@ -637,6 +643,12 @@ export class MercuryClient {
       const subs = await this.getAccountSubForPubKey(pubKey, network);
       const hasSubs = hasSubForPublicKey(subs, pubKey);
       if (!hasSubs) {
+        const { error } = await this.accountSubscription(pubKey, network);
+        if (!error) {
+          this.logger.info(
+            `Subscribed to missing account sub - ${pubKey} - ${network}`
+          );
+        }
         throw new Error(ERROR.MISSING_SUB_FOR_PUBKEY);
       }
 
@@ -651,6 +663,16 @@ export class MercuryClient {
         );
         const hasTokenSubs = hasSubForTokenBalance(tokenSubs, contractId);
         if (!hasTokenSubs) {
+          const { error } = await this.tokenBalanceSubscription(
+            contractId,
+            pubKey,
+            network
+          );
+          if (!error) {
+            this.logger.info(
+              `Subscribed to missing token balance sub - ${contractId} - ${pubKey} - ${network}`
+            );
+          }
           throw new Error(ERROR.MISSING_SUB_FOR_TOKEN_BALANCE);
         }
         const details = await this.tokenDetails(pubKey, contractId, network);


### PR DESCRIPTION
What
This adds calls to subscribe to account or token balances in the case that a GET to them is called when Mercury is enabled but has no subscription for the resource.

Why
This will help us catch missing subs and set the subs up while still falling back to Horizon/RPC during the missing request, allowing for the next instance of that request to be served by Mercury.
This will help with the transition to Mercury, as there will be in flight sessions/existing tokens in storage that will likely hit this condition.