### PR TITLE
[FEATURE] current data api

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,12 @@ export function buildConfig(config: Record<string, string>) {
     mercuryGraphQLTestnet: "https://api.mercurydata.app:2083/graphql",
     mercuryBackendPubnet: "https://mainnet.mercurydata.app:8443",
     mercuryGraphQLPubnet: "https://mainnet.mercurydata.app:2083/graphql",
+
+    mercuryGraphQLCurrentDataTestnet:
+      "https://api.mercurydata.app:2096/graphql",
+    mercuryGraphQLCurrentDataPubnet:
+      "https://mainnet.mercurydata.app:2096/graphql",
+
     mercuryEmail: config.AUTH_EMAIL || process.env.AUTH_EMAIL!,
     mercuryKey: config.MERCURY_KEY || process.env.MERCURY_KEY!,
     mercuryPassword: config.AUTH_PASS || process.env.AUTH_PASS!,

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,12 +33,10 @@ export function buildConfig(config: Record<string, string>) {
     mercuryGraphQLTestnet: "https://api.mercurydata.app:2083/graphql",
     mercuryBackendPubnet: "https://mainnet.mercurydata.app:8443",
     mercuryGraphQLPubnet: "https://mainnet.mercurydata.app:2083/graphql",
-
     mercuryGraphQLCurrentDataTestnet:
       "https://api.mercurydata.app:2096/graphql",
     mercuryGraphQLCurrentDataPubnet:
       "https://mainnet.mercurydata.app:2096/graphql",
-
     mercuryEmail: config.AUTH_EMAIL || process.env.AUTH_EMAIL!,
     mercuryKey: config.MERCURY_KEY || process.env.MERCURY_KEY!,
     mercuryPassword: config.AUTH_PASS || process.env.AUTH_PASS!,

--- a/src/helper/soroban-rpc/index.ts
+++ b/src/helper/soroban-rpc/index.ts
@@ -16,7 +16,7 @@ import {
   ContractSpec,
 } from "stellar-sdk";
 import { XdrReader } from "@stellar/js-xdr";
-import { NetworkNames } from "../validate";
+import { isPubKey, NetworkNames } from "../validate";
 import { ERROR } from "../error";
 import { Logger } from "pino";
 
@@ -386,6 +386,17 @@ const isTokenSpec = (spec: Record<string, any>) => {
   return true;
 };
 
+// We can know when a token contract is a SAC instance by getting the name field, and checking for
+// the name to follow the pattern "assetId:issuer".
+const isSacIssuer = (name: string) => {
+  const issuerParts = name.split(":");
+  const [_, issuer] = issuerParts;
+  if (issuerParts.length > 1 && isPubKey(issuer)) {
+    return true;
+  }
+  return false;
+};
+
 export {
   buildTransfer,
   getLedgerKeyContractCode,
@@ -399,6 +410,7 @@ export {
   getTokenSpec,
   getTokenSymbol,
   getTxBuilder,
+  isSacIssuer,
   isTokenSpec,
   parseWasmXdr,
   simulateTx,

--- a/src/helper/test-helper.ts
+++ b/src/helper/test-helper.ts
@@ -175,7 +175,6 @@ function backendClientMaker(network: NetworkNames) {
         });
       }
       default:
-        console.log(_query);
         throw new Error("unknown query in mock");
     }
   });

--- a/src/helper/test-helper.ts
+++ b/src/helper/test-helper.ts
@@ -137,7 +137,45 @@ function backendClientMaker(network: NetworkNames) {
           error: null,
         });
       }
+      case query.getCurrentDataAccountBalances(
+        pubKey,
+        tokenBalanceLedgerKey,
+        []
+      ): {
+        return Promise.resolve({
+          data: queryMockResponse["query.getAccountBalancesCurrentData"],
+          error: null,
+        });
+      }
+      case query.getCurrentDataAccountBalances(pubKey, tokenBalanceLedgerKey, [
+        "CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP",
+      ]): {
+        return Promise.resolve({
+          data: queryMockResponse[
+            "query.getAccountBalancesCurrentDataWithFirstContracts"
+          ],
+          error: null,
+        });
+      }
+      case query.getCurrentDataAccountBalances(pubKey, tokenBalanceLedgerKey, [
+        "CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP",
+        "CBGTG7XFRY3L6OKAUTR6KGDKUXUQBX3YDJ3QFDYTGVMOM7VV4O7NCODG",
+      ]): {
+        return Promise.resolve({
+          data: queryMockResponse[
+            "query.getAccountBalancesCurrentDataWithBothContracts"
+          ],
+          error: null,
+        });
+      }
+      case query.getAccountObject(pubKey): {
+        return Promise.resolve({
+          data: queryMockResponse["query.getAccountObject"],
+          error: null,
+        });
+      }
       default:
+        console.log(_query);
         throw new Error("unknown query in mock");
     }
   });
@@ -161,6 +199,7 @@ const mercurySession = {
   token: "mercury-token",
   renewClientMaker,
   backendClientMaker,
+  currentDataClientMaker: backendClientMaker,
   backends,
   email: "user-email",
   password: "user-password",
@@ -169,6 +208,8 @@ const mercurySession = {
 
 const valueXdr = nativeToScVal(1).toXDR();
 const pubKey = "GCGORBD5DB4JDIKVIA536CJE3EWMWZ6KBUBWZWRQM7Y3NHFRCLOKYVAL";
+const contractDataEntryValXdr =
+  "AAA5zAAAAAYAAAAAAAAAAY6oGxM6ldCYnaiGZ39Qfe7OU9/hMzrwkVF8OBHpqKMTAAAAEAAAAAEAAAACAAAADwAAAAdCYWxhbmNlAAAAABIAAAAAAAAAAIzohH0YeJGhVUA7vwkk2SzLZ8oNA2zaMGfxtpyxEtysAAAAAQAAAAoAAAAAAAAAAAAAAAAAAAAKAAAAAA==";
 const tokenBalanceLedgerKey =
   "AAAAEAAAAAEAAAACAAAADwAAAAdCYWxhbmNlAAAAABIAAAAAAAAAAIzohH0YeJGhVUA7vwkk2SzLZ8oNA2zaMGfxtpyxEtys";
 
@@ -176,6 +217,79 @@ const queryMockResponse = {
   [mutation.authenticate]: {
     authenticate: {
       jwtToken: "mercury-token",
+    },
+  },
+  "query.getAccountBalancesCurrentData": {
+    trustlinesByPublicKey: [
+      {
+        balance: 100019646386,
+        asset: "AAAAAUJMTkQAAAAAJgXM07IdPwaDCLLNw46HAu0Jy3Az9GJKesWnsk57zF4=",
+        limit: 1,
+        accountId: pubKey,
+      },
+    ],
+  },
+  "query.getAccountBalancesCurrentDataWithFirstContracts": {
+    trustlinesByPublicKey: [
+      {
+        balance: 100019646386,
+        asset: "AAAAAUJMTkQAAAAAJgXM07IdPwaDCLLNw46HAu0Jy3Az9GJKesWnsk57zF4=",
+        limit: 1,
+        accountId: pubKey,
+      },
+    ],
+    CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP: [
+      {
+        contractId: "CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP",
+        keyXdr:
+          "AAAAEAAAAAEAAAACAAAADwAAAAdCYWxhbmNlAAAAABIAAAAAAAAAAIzohH0YeJGhVUA7vwkk2SzLZ8oNA2zaMGfxtpyxEtys",
+        valXdr: contractDataEntryValXdr,
+        durability: 1,
+      },
+    ],
+  },
+  "query.getAccountBalancesCurrentDataWithBothContracts": {
+    trustlinesByPublicKey: [
+      {
+        balance: 100019646386,
+        asset: "AAAAAUJMTkQAAAAAJgXM07IdPwaDCLLNw46HAu0Jy3Az9GJKesWnsk57zF4=",
+        limit: 1,
+        accountId: pubKey,
+      },
+    ],
+    CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP: [
+      {
+        contractId: "CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP",
+        keyXdr:
+          "AAAAEAAAAAEAAAACAAAADwAAAAdCYWxhbmNlAAAAABIAAAAAAAAAAIzohH0YeJGhVUA7vwkk2SzLZ8oNA2zaMGfxtpyxEtys",
+        valXdr: contractDataEntryValXdr,
+        durability: 1,
+      },
+    ],
+    CBGTG7XFRY3L6OKAUTR6KGDKUXUQBX3YDJ3QFDYTGVMOM7VV4O7NCODG: [
+      {
+        contractId: "CBGTG7XFRY3L6OKAUTR6KGDKUXUQBX3YDJ3QFDYTGVMOM7VV4O7NCODG",
+        keyXdr:
+          "AAAAEAAAAAEAAAACAAAADwAAAAdCYWxhbmNlAAAAABIAAAAAAAAAAIzohH0YeJGhVUA7vwkk2SzLZ8oNA2zaMGfxtpyxEtys",
+        valXdr: contractDataEntryValXdr,
+        durability: 1,
+      },
+    ],
+  },
+  "query.getAccountObject": {
+    accountObjectByPublicKey: {
+      nodes: [
+        {
+          accountByAccount: {
+            publickey: pubKey,
+          },
+          nativeBalance: "10",
+          numSubEntries: "1",
+          numSponsored: "1",
+          numSponsoring: "1",
+          sellingLiabilities: "1",
+        },
+      ],
     },
   },
   "query.getAccountBalances": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,11 @@ async function main() {
     PUBLIC: conf.mercuryGraphQLPubnet,
   };
 
+  const graphQlCurrentDataEndpoints = {
+    TESTNET: conf.mercuryGraphQLCurrentDataTestnet,
+    PUBLIC: conf.mercuryGraphQLCurrentDataPubnet,
+  };
+
   const backends = {
     TESTNET: conf.mercuryBackendTestnet,
     PUBLIC: conf.mercuryBackendPubnet,
@@ -87,10 +92,32 @@ async function main() {
     });
   };
 
+  const currentDataClientMaker = (
+    network: NetworkNames,
+    key: string = conf.mercuryKey
+  ) => {
+    if (!hasIndexerSupport(network)) {
+      throw new Error(`network not currently supported: ${network}`);
+    }
+
+    return new Client({
+      url: `${
+        graphQlCurrentDataEndpoints[network as MercurySupportedNetworks]
+      }`,
+      exchanges: [fetchExchange],
+      fetchOptions: () => {
+        return {
+          headers: { authorization: `Bearer ${key}` },
+        };
+      },
+    });
+  };
+
   const mercurySession = {
     token: conf.mercuryKey,
     renewClientMaker,
     backendClientMaker,
+    currentDataClientMaker,
     backends,
     email: conf.mercuryEmail,
     password: conf.mercuryPassword,

--- a/src/service/mercury/helpers/transformers.ts
+++ b/src/service/mercury/helpers/transformers.ts
@@ -160,7 +160,9 @@ const transformAccountBalancesCurrentData = async (
 
       case "assetTypeCreditAlphanum12": {
         const code = trustline.alphaNum12().assetCode().toString();
-        const issuer = trustline.alphaNum12().issuer().toString();
+        const issuer = StrKey.encodeEd25519PublicKey(
+          trustline.alphaNum12().issuer().ed25519()
+        );
         prev[`${code}:${issuer}`] = {
           token: {
             code,
@@ -193,11 +195,12 @@ const transformAccountBalancesCurrentData = async (
 
   const formattedBalances = tokenBalanceData.map(([entry]) => {
     const details = tokenDetails[entry.contractId];
-    const totalScVal = xdr.ScVal.fromXDR(Buffer.from(entry.valXdr, "base64"));
+    const valEntry = xdr.LedgerEntry.fromXDR(entry.valXdr, "base64");
+    const val = valEntry.data().contractData().val();
     return {
       ...entry,
       ...details,
-      total: scValToNative(totalScVal),
+      total: scValToNative(val),
     };
   });
 

--- a/src/service/mercury/helpers/transformers.ts
+++ b/src/service/mercury/helpers/transformers.ts
@@ -177,8 +177,7 @@ const transformAccountBalancesCurrentData = async (
       }
 
       case "assetTypePoolShare": {
-        console.log(`pool share: ${trustline.value()}`);
-        // TODO
+        // Should pool shares be decoded here?
         return prev;
       }
 

--- a/src/service/mercury/helpers/transformers.ts
+++ b/src/service/mercury/helpers/transformers.ts
@@ -8,7 +8,7 @@ import {
   getAssetType,
 } from "../../../helper/horizon-rpc";
 import { formatTokenAmount } from "../../../helper/format";
-import { getOpArgs } from "../../../helper/soroban-rpc";
+import { getOpArgs, isSacIssuer } from "../../../helper/soroban-rpc";
 
 // Transformers take an API response, and transform it/augment it for frontend consumption
 
@@ -203,20 +203,22 @@ const transformAccountBalancesCurrentData = async (
     };
   });
 
-  const balances = formattedBalances.reduce((prev, curr) => {
-    prev[`${curr.symbol}:${curr.contractId}`] = {
-      token: {
-        code: curr.symbol,
-        issuer: {
-          key: curr.contractId,
+  const balances = formattedBalances
+    .filter((bal) => !isSacIssuer(bal.name))
+    .reduce((prev, curr) => {
+      prev[`${curr.symbol}:${curr.contractId}`] = {
+        token: {
+          code: curr.symbol,
+          issuer: {
+            key: curr.contractId,
+          },
         },
-      },
-      decimals: curr.decimals,
-      total: new BigNumber(curr.total),
-      available: new BigNumber(curr.total),
-    };
-    return prev;
-  }, {} as NonNullable<AccountBalancesInterface["balances"]>);
+        decimals: curr.decimals,
+        total: new BigNumber(curr.total),
+        available: new BigNumber(curr.total),
+      };
+      return prev;
+    }, {} as NonNullable<AccountBalancesInterface["balances"]>);
 
   return {
     balances: {

--- a/src/service/mercury/index.test.ts
+++ b/src/service/mercury/index.test.ts
@@ -6,7 +6,7 @@ import {
   queryMockResponse,
   pubKey,
 } from "../../helper/test-helper";
-import { transformAccountBalances } from "./helpers/transformers";
+import { transformAccountBalancesCurrentData } from "./helpers/transformers";
 import { ERROR_MESSAGES } from ".";
 import { ERROR } from "../../helper/error";
 
@@ -65,8 +65,14 @@ describe("Mercury Service", () => {
         decimals: 7,
       },
     };
-    const transformedData = await transformAccountBalances(
-      { data: queryMockResponse["query.getAccountBalances"] } as any,
+
+    const transformedData = await transformAccountBalancesCurrentData(
+      {
+        data: queryMockResponse[
+          "query.getAccountBalancesCurrentDataWithBothContracts"
+        ],
+      } as any,
+      { data: queryMockResponse["query.getAccountObject"] } as any,
       tokenDetails as any,
       [
         "CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP",
@@ -258,53 +264,5 @@ describe("Mercury Service", () => {
       expect(response.error.message).toContain(ERROR.MISSING_SUB_FOR_PUBKEY);
     }
     expect(mockMercuryClient.accountSubscription).toHaveBeenCalled();
-  });
-
-  it("will correctly handle missing token balance subscriptions", async () => {
-    jest
-      .spyOn(mockMercuryClient, "getAccountSubForPubKey")
-      .mockImplementation(
-        (
-          ..._args: Parameters<typeof mockMercuryClient.getAccountSubForPubKey>
-        ): ReturnType<typeof mockMercuryClient.getAccountSubForPubKey> => {
-          return Promise.resolve([{ publickey: pubKey }]);
-        }
-      );
-
-    jest
-      .spyOn(mockMercuryClient, "getTokenBalanceSub")
-      .mockImplementation(
-        (
-          ..._args: Parameters<typeof mockMercuryClient.getTokenBalanceSub>
-        ): ReturnType<typeof mockMercuryClient.getTokenBalanceSub> => {
-          return Promise.resolve([{ contractId: "nope" }]);
-        }
-      );
-
-    jest
-      .spyOn(mockMercuryClient, "tokenBalanceSubscription")
-      .mockImplementation(
-        (
-          ..._args: Parameters<
-            typeof mockMercuryClient.tokenBalanceSubscription
-          >
-        ): ReturnType<typeof mockMercuryClient.tokenBalanceSubscription> => {
-          return Promise.resolve({ data: {}, error: null });
-        }
-      );
-
-    const response = await mockMercuryClient.getAccountBalancesMercury(
-      pubKey,
-      ["CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP"],
-      "TESTNET"
-    );
-    expect(response).toHaveProperty("error");
-    expect(response.error).toBeInstanceOf(Error);
-    if (response.error instanceof Error) {
-      expect(response.error.message).toContain(
-        ERROR.MISSING_SUB_FOR_TOKEN_BALANCE
-      );
-    }
-    expect(mockMercuryClient.tokenBalanceSubscription).toHaveBeenCalled();
   });
 });

--- a/src/service/mercury/index.ts
+++ b/src/service/mercury/index.ts
@@ -1,4 +1,4 @@
-import { Client, CombinedError, OperationResult } from "@urql/core";
+import { Client, CombinedError } from "@urql/core";
 import axios from "axios";
 import { Logger } from "pino";
 import { Address, Horizon, xdr } from "stellar-sdk";
@@ -17,7 +17,6 @@ import {
   getTxBuilder,
 } from "../../helper/soroban-rpc";
 import {
-  transformAccountBalances,
   transformAccountBalancesCurrentData,
   transformAccountHistory,
 } from "./helpers/transformers";
@@ -34,7 +33,6 @@ import {
   MercurySupportedNetworks,
   hasIndexerSupport,
   hasSubForPublicKey,
-  hasSubForTokenBalance,
 } from "../../helper/mercury";
 
 const DEFAULT_RETRY_AMOUNT = 5;
@@ -657,6 +655,10 @@ export class MercuryClient {
       const tokenDetails = {} as {
         [index: string]: Awaited<ReturnType<MercuryClient["tokenDetails"]>>;
       };
+      for (const contractId of contractIds) {
+        const details = await this.tokenDetails(pubKey, contractId, network);
+        tokenDetails[contractId] = details;
+      }
 
       const getData = async () => {
         const urqlClientCurrentData =

--- a/src/service/mercury/queries.ts
+++ b/src/service/mercury/queries.ts
@@ -35,6 +35,49 @@ export const query = {
       }
     }
   `,
+  getCurrentDataAccountBalances: (
+    pubKey: string,
+    ledgerKey: string,
+    contractIds: string[]
+  ) => `
+    query AccountBalancesCurrentData {
+      trustlinesByPublicKey(public: "${pubKey}") {
+        balance
+        asset
+        limit
+        accountId
+      }
+
+      ${contractIds.map(
+        (id) => `
+        ${id}: contractDataEntriesByContractAndKeys(contract: "${id}", keys: ["${ledgerKey}"]) {
+          contractId,
+          keyXdr,
+          valXdr,
+          durability
+        }
+        `
+      )}
+    }
+  `,
+  getAccountObject: (pubKey: string) => `
+    query AccountObject {
+      accountObjectByPublicKey(
+        publicKeyText: "${pubKey}"
+      ) {
+        nodes {
+          accountByAccount {
+            publickey
+          }
+          nativeBalance
+          numSubEntries
+          numSponsored
+          numSponsoring
+          sellingLiabilities
+        }
+      }
+    }
+  `,
   getAccountBalances: (
     pubKey: string,
     ledgerKey: string,


### PR DESCRIPTION
What
Implements a new API from Mercury that keeps track of the most recent data for trustlines and contract entries without the need for a subscription, uses this API in `getAccountBalance`

Why
Mercury added the "current data API" which gives access to latest values for trustline balances and contract entries(token balances) without setting up a subscription. Using the current data API we can build the view of data that we need for account balances without having to rely on/check subscriptions. This should result in faster queries against Mercury for account balances.