### PR TITLE
[FIX] account object extra fields

### DIFF
--- a/src/service/mercury/helpers/transformers.ts
+++ b/src/service/mercury/helpers/transformers.ts
@@ -122,12 +122,18 @@ const transformAccountBalancesCurrentData = async (
     native: {
       token: { type: "native", code: "XLM" },
       total: formatTokenAmount(new BigNumber(nativeBalance), 7),
-      available: new BigNumber(BASE_RESERVE_MIN_COUNT)
+      available: formatTokenAmount(
+        new BigNumber(nativeBalance).minus(new BigNumber(sellingLiabilities)),
+        7
+      ),
+      minimumBalance: new BigNumber(BASE_RESERVE_MIN_COUNT)
         .plus(new BigNumber(numSubEntries))
         .plus(new BigNumber(numSponsoring))
         .minus(new BigNumber(numSponsored))
         .times(new BigNumber(BASE_RESERVE))
-        .plus(new BigNumber(sellingLiabilities)),
+        .plus(
+          new BigNumber(formatTokenAmount(new BigNumber(sellingLiabilities), 7))
+        ),
     },
   };
 


### PR DESCRIPTION
What
Adds `minimumBalance` key to Mercury account object transformer
Fixes the calc for `available`

Why
Horizon returns a `minimumBalance` key which is unused by the UI right now but this will now match the Horizon response more closely
`available` field was being calculated as the `minimumBalance`, unused in the UI but this fixes that discrepancy. 