### PR TITLE
[FEATURE] adds account object query to current data api, replaces subscription

### DIFF
--- a/src/helper/test-helper.ts
+++ b/src/helper/test-helper.ts
@@ -227,6 +227,14 @@ const queryMockResponse = {
         accountId: pubKey,
       },
     ],
+    accountByPublicKey: {
+      accountId: pubKey,
+      nativeBalance: "10",
+      numSubEntries: "1",
+      numSponsored: "1",
+      numSponsoring: "1",
+      sellingLiabilities: "1000000",
+    },
   },
   "query.getAccountBalancesCurrentDataWithFirstContracts": {
     trustlinesByPublicKey: [
@@ -237,6 +245,14 @@ const queryMockResponse = {
         accountId: pubKey,
       },
     ],
+    accountByPublicKey: {
+      accountId: pubKey,
+      nativeBalance: "10",
+      numSubEntries: "1",
+      numSponsored: "1",
+      numSponsoring: "1",
+      sellingLiabilities: "1000000",
+    },
     CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP: [
       {
         contractId: "CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP",
@@ -256,6 +272,14 @@ const queryMockResponse = {
         accountId: pubKey,
       },
     ],
+    accountByPublicKey: {
+      accountId: pubKey,
+      nativeBalance: "10",
+      numSubEntries: "1",
+      numSponsored: "1",
+      numSponsoring: "1",
+      sellingLiabilities: "1000000",
+    },
     CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP: [
       {
         contractId: "CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP",

--- a/src/service/mercury/index.test.ts
+++ b/src/service/mercury/index.test.ts
@@ -74,7 +74,6 @@ describe("Mercury Service", () => {
           "query.getAccountBalancesCurrentDataWithBothContracts"
         ],
       } as any,
-      { data: queryMockResponse["query.getAccountObject"] } as any,
       tokenDetails as any,
       [
         "CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP",
@@ -166,73 +165,6 @@ describe("Mercury Service", () => {
     // It would retry 5 times, but we can only mock reject once or all so it rejects once, then succeeds.
     expect(mockRetryable).toHaveBeenCalledTimes(2);
     expect(spyRenewToken).not.toHaveBeenCalled();
-  });
-
-  it("getAccountBalancesMercury throws when there is no sub for public key", async () => {
-    jest
-      .spyOn(mockMercuryClient, "getAccountSubForPubKey")
-      .mockImplementation(
-        (
-          ..._args: Parameters<typeof mockMercuryClient.getAccountSubForPubKey>
-        ): ReturnType<typeof mockMercuryClient.getAccountSubForPubKey> => {
-          return Promise.resolve([{ publickey: "nope" }]);
-        }
-      );
-
-    jest
-      .spyOn(mockMercuryClient, "accountSubscription")
-      .mockImplementation(
-        (
-          ..._args: Parameters<typeof mockMercuryClient.accountSubscription>
-        ): ReturnType<typeof mockMercuryClient.accountSubscription> => {
-          return Promise.resolve({ data: {}, error: null });
-        }
-      );
-
-    const response = await mockMercuryClient.getAccountBalancesMercury(
-      pubKey,
-      [],
-      "TESTNET"
-    );
-    expect(response).toHaveProperty("error");
-    expect(response.error).toBeInstanceOf(Error);
-    if (response.error instanceof Error) {
-      expect(response.error.message).toContain(ERROR.MISSING_SUB_FOR_PUBKEY);
-    }
-  });
-
-  it("will correctly handle missing account subscriptions when fetching balances", async () => {
-    jest
-      .spyOn(mockMercuryClient, "getAccountSubForPubKey")
-      .mockImplementation(
-        (
-          ..._args: Parameters<typeof mockMercuryClient.getAccountSubForPubKey>
-        ): ReturnType<typeof mockMercuryClient.getAccountSubForPubKey> => {
-          return Promise.resolve([{ publickey: "nope" }]);
-        }
-      );
-
-    jest
-      .spyOn(mockMercuryClient, "accountSubscription")
-      .mockImplementation(
-        (
-          ..._args: Parameters<typeof mockMercuryClient.accountSubscription>
-        ): ReturnType<typeof mockMercuryClient.accountSubscription> => {
-          return Promise.resolve({ data: {}, error: null });
-        }
-      );
-
-    const response = await mockMercuryClient.getAccountBalancesMercury(
-      pubKey,
-      [],
-      "TESTNET"
-    );
-    expect(response).toHaveProperty("error");
-    expect(response.error).toBeInstanceOf(Error);
-    if (response.error instanceof Error) {
-      expect(response.error.message).toContain(ERROR.MISSING_SUB_FOR_PUBKEY);
-    }
-    expect(mockMercuryClient.accountSubscription).toHaveBeenCalled();
   });
 
   it("will correctly handle missing account subscriptions when fetching history", async () => {

--- a/src/service/mercury/queries.ts
+++ b/src/service/mercury/queries.ts
@@ -48,6 +48,17 @@ export const query = {
         accountId
       }
 
+      accountByPublicKey(public: "${pubKey}") {
+        accountId
+        nativeBalance
+        buyingLiabilities
+        sellingLiabilities
+        seqNum
+        numSubentries
+        numSponsored
+        numSponsoring
+      }
+
       ${contractIds.map(
         (id) => `
         ${id}: contractDataEntriesByContractAndKeys(contract: "${id}", keys: ["${ledgerKey}"]) {


### PR DESCRIPTION
What
Adds account object query from the current data API, replaces use of account object query from the subscription based API

Why
This data is available in the current data API and will significantly improve our query performance on the account balances queries through Mercury