### PR TITLE
fixes config check to include vars set in shell

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -17,7 +17,7 @@ export function buildConfig(config: Record<string, string>) {
   const missingKeys = [] as string[];
 
   const isMissingKeys = ENV_KEYS.every((key) => {
-    if (configKeys.includes(key)) {
+    if (configKeys.includes(key) || process.env[key]) {
       return true;
     }
     missingKeys.push(key);


### PR DESCRIPTION
What
Fixes config check to allow vars set directly in env and not loaded through .env files

Why
This check was incorrectly failing in CI because we use a combo of env vars and .env file vars there.