### PR TITLE
adds getContractSpec route

### DIFF
--- a/src/helper/soroban-rpc/index.ts
+++ b/src/helper/soroban-rpc/index.ts
@@ -264,7 +264,7 @@ const getLedgerEntries = async (
   return json;
 };
 
-const getTokenSpec = async (
+const getContractSpec = async (
   contractId: string,
   network: NetworkNames,
   logger: Logger
@@ -283,7 +283,7 @@ const getTokenSpec = async (
     const entries = result.entries || [];
     if (error || !entries.length) {
       logger.error(error);
-      return { error: "Unable to fetch token spec", result: null };
+      return { error: "Unable to fetch contract spec", result: null };
     }
 
     const contractCodeLedgerEntryData = entries[0].xdr;
@@ -295,11 +295,25 @@ const getTokenSpec = async (
     const wasmEntries = wasmResult.entries || [];
     if (wasmError || !wasmEntries.length) {
       logger.error(wasmError);
-      return { error: "Unable to fetch token spec", result: null };
+      return { error: "Unable to fetch contract spec", result: null };
     }
 
-    const wasm = await parseWasmXdr(wasmEntries[0].xdr);
-    return { error: null, result: isTokenSpec(wasm) };
+    const spec = await parseWasmXdr(wasmEntries[0].xdr);
+    return { result: spec, error: null };
+  } catch (error) {
+    logger.error(error);
+    return { error: "Unable to fetch contract spec", result: null };
+  }
+};
+
+const getIsTokenSpec = async (
+  contractId: string,
+  network: NetworkNames,
+  logger: Logger
+) => {
+  try {
+    const spec = await getContractSpec(contractId, network, logger);
+    return { error: null, result: isTokenSpec(spec) };
   } catch (error) {
     logger.error(error);
     return { error: "Unable to fetch token spec", result: null };
@@ -431,19 +445,20 @@ const isSacContract = (name: string, contractId: string, network: Networks) => {
 
 export {
   buildTransfer,
+  getContractSpec,
+  getIsTokenSpec,
+  getLedgerEntries,
   getLedgerKeyContractCode,
   getLedgerKeyWasmId,
-  getLedgerEntries,
   getOpArgs,
   getServer,
   getTokenBalance,
   getTokenDecimals,
   getTokenName,
-  getTokenSpec,
   getTokenSymbol,
   getTxBuilder,
-  isSacContractExecutable,
   isSacContract,
+  isSacContractExecutable,
   isTokenSpec,
   parseWasmXdr,
   simulateTx,

--- a/src/route/index.ts
+++ b/src/route/index.ts
@@ -30,7 +30,8 @@ import {
 import {
   SOROBAN_RPC_URLS,
   buildTransfer,
-  getTokenSpec,
+  getContractSpec,
+  getIsTokenSpec,
   simulateTx,
 } from "../helper/soroban-rpc";
 import { ERROR } from "../helper/error";
@@ -394,7 +395,7 @@ export async function initApiServer(
           }
 
           try {
-            const { result, error } = await getTokenSpec(
+            const { result, error } = await getIsTokenSpec(
               contractId,
               network,
               logger
@@ -405,6 +406,54 @@ export async function initApiServer(
             } else {
               reply.code(200).send({ isSep41Compliant: result, error: null });
             }
+          } catch (error) {
+            reply.code(500).send("Unexpected Server Error");
+          }
+        },
+      });
+
+      instance.route({
+        method: "GET",
+        url: "/contract-spec/:contractId",
+        schema: {
+          params: {
+            ["contractId"]: {
+              type: "string",
+              validator: (qStr: string) => isContractId(qStr),
+            },
+          },
+          querystring: {
+            ["network"]: {
+              type: "string",
+              validator: (qStr: string) => isNetwork(qStr),
+            },
+          },
+        },
+        handler: async (
+          request: FastifyRequest<{
+            Params: { ["contractId"]: string };
+            Querystring: {
+              ["network"]: NetworkNames;
+            };
+          }>,
+          reply
+        ) => {
+          const contractId = request.params["contractId"];
+          const { network } = request.query;
+
+          const skipSorobanPubnet = network === "PUBLIC" && !useSorobanPublic;
+          if (skipSorobanPubnet) {
+            return reply.code(400).send("Soroban has been disabled on pubnet");
+          }
+
+          try {
+            const { result, error } = await getContractSpec(
+              contractId,
+              network,
+              logger
+            );
+
+            reply.code(error ? 400 : 200).send({ data: result, error });
           } catch (error) {
             reply.code(500).send("Unexpected Server Error");
           }


### PR DESCRIPTION
What
Adds getContractSpec route

Why
For use during transaction signing to expose more detail about contract spec.