### PR TITLE
[BUG] Fix metric cardinality for http_request_duration_s

### DIFF
--- a/src/helper/metrics.ts
+++ b/src/helper/metrics.ts
@@ -1,0 +1,60 @@
+import { FastifyReply, FastifyRequest } from "fastify";
+
+export const httpLabelUrl = (method: string) => {
+  const [route, search] = method.split("?");
+  const params = new URLSearchParams(search);
+  const network = params.get("network") || "unknown";
+
+  if (method.includes("account-history")) {
+    return {
+      route: "account-history",
+      network,
+    };
+  }
+
+  if (method.includes("account-balances")) {
+    return {
+      route: "account-balances",
+      network,
+    };
+  }
+
+  if (method.includes("token-details")) {
+    return {
+      route: "token-details",
+      network,
+    };
+  }
+
+  if (method.includes("token-spec")) {
+    return {
+      route: "token-spec",
+      network,
+    };
+  }
+
+  if (method.includes("contract-spec")) {
+    return {
+      route: "contract-spec",
+      network,
+    };
+  }
+
+  return {
+    route,
+    network,
+  };
+};
+
+export const getHttpRequestDurationLabels = (
+  request: FastifyRequest,
+  reply: FastifyReply
+) => {
+  const { route, network } = httpLabelUrl(request.method);
+  return {
+    method: request.method,
+    route,
+    network,
+    status: reply.statusCode,
+  };
+};

--- a/src/helper/test/metrics.test.ts
+++ b/src/helper/test/metrics.test.ts
@@ -1,0 +1,24 @@
+import { httpLabelUrl } from "../metrics";
+
+describe("httpLabelUrl", () => {
+  it("should return an account-history label for relevant routes", () => {
+    const network = "PUBLIC";
+    const route = "account-history";
+    const labels = httpLabelUrl(`/api/v1/${route}?network=${network}`);
+    expect(labels.network).toEqual(network);
+    expect(labels.route).toEqual(route);
+  });
+  it("should return an account-balances label for relevant routes", () => {
+    const network = "TESTNET";
+    const route = "account-balances";
+    const labels = httpLabelUrl(`/api/v1/${route}?network=${network}`);
+    expect(labels.network).toEqual(network);
+    expect(labels.route).toEqual(route);
+  });
+  it("should return the full URL in fall through cases", () => {
+    const route = "some-route";
+    const labels = httpLabelUrl(`/api/v1/${route}`);
+    expect(labels.network).toEqual("unknown");
+    expect(labels.route).toEqual(`/api/v1/${route}`);
+  });
+});

--- a/src/route/index.ts
+++ b/src/route/index.ts
@@ -27,6 +27,7 @@ import { ERROR } from "../helper/error";
 import axios from "axios";
 import { getSdk } from "../helper/stellar";
 import { Networks } from "stellar-sdk-next";
+import { getHttpRequestDurationLabels } from "../helper/metrics";
 
 const API_VERSION = "v1";
 
@@ -45,7 +46,7 @@ export async function initApiServer(
   const httpRequestDurationMicroseconds = new Prometheus.Histogram({
     name: "http_request_duration_s",
     help: "Duration of HTTP requests in seconds",
-    labelNames: ["method", "route", "status"],
+    labelNames: ["method", "route", "status", "network"],
     buckets: [0.1, 0.5, 1, 2, 5],
     registers: [register],
   });
@@ -82,11 +83,7 @@ export async function initApiServer(
       return done();
     }
 
-    const labels = {
-      method: request.method,
-      route: request.url,
-      status: reply.statusCode,
-    };
+    const labels = getHttpRequestDurationLabels(request, reply);
     histMetric(labels);
     return done();
   });


### PR DESCRIPTION
What
Fixes the cardinality problem in the `http_request_duration_s` metric
Adds network label

Why
Each route slug and param was being tracked as it's own label, exploding the cardinality of this metric type.