### PR TITLE
[FEATURE] Integrity check runs in worker

### DIFF
--- a/src/helper/fetch.ts
+++ b/src/helper/fetch.ts
@@ -1,0 +1,15 @@
+// Why does NodeJS.fetch.RequestInfo not work for URL?
+export function fetchWithTimeout(
+  url: any,
+  opts?: NodeJS.fetch.RequestInit
+): Promise<NodeJS.fetch.Response> {
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), 5000);
+
+  return fetch(url, {
+    ...opts,
+    signal: controller.signal,
+  }).finally(() => {
+    clearTimeout(id);
+  });
+}

--- a/src/helper/metrics.ts
+++ b/src/helper/metrics.ts
@@ -1,4 +1,31 @@
 import { FastifyReply, FastifyRequest } from "fastify";
+import Prometheus from "prom-client";
+
+export const register = new Prometheus.Registry();
+register.setDefaultLabels({
+  app: "freighter-backend",
+});
+
+export const mercuryErrorCounter = new Prometheus.Counter({
+  name: "freighter_backend_mercury_error_count",
+  help: "Count of errors returned from Mercury",
+  labelNames: ["endpoint"],
+  registers: [register],
+});
+
+export const rpcErrorCounter = new Prometheus.Counter({
+  name: "freighter_backend_rpc_error_count",
+  help: "Count of errors returned from Horizon or Soroban RPCs",
+  labelNames: ["rpc"],
+  registers: [register],
+});
+
+export const criticalError = new Prometheus.Counter({
+  name: "freighter_backend_critical_error_count",
+  help: "Count of errors that need manual operator intervention or investigation",
+  labelNames: ["message"],
+  registers: [register],
+});
 
 export const httpLabelUrl = (url: string) => {
   const [route, search] = url.split("?");

--- a/src/service/integrity-checker/worker.ts
+++ b/src/service/integrity-checker/worker.ts
@@ -1,0 +1,108 @@
+import { Redis } from "ioredis";
+
+import { workerData } from "worker_threads";
+import { IntegrityChecker } from ".";
+import { logger } from "../../logger";
+import {
+  buildBackendClientMaker,
+  buildCurrentDataClientMaker,
+  buildRenewClientMaker,
+} from "../../helper/mercury";
+import { MercuryClient } from "../mercury";
+import {
+  register,
+  mercuryErrorCounter,
+  rpcErrorCounter,
+  criticalError,
+} from "../../helper/metrics";
+
+const {
+  hostname,
+  mercuryBackendPubnet,
+  mercuryBackendTestnet,
+  mercuryEmailTestnet,
+  mercuryGraphQLCurrentDataPubnet,
+  mercuryGraphQLCurrentDataTestnet,
+  mercuryGraphQLPubnet,
+  mercuryGraphQLTestnet,
+  mercuryIntegrityCheckEmail,
+  mercuryIntegrityCheckPass,
+  mercuryPasswordTestnet,
+  redisConnectionName,
+  redisPort,
+} = workerData;
+
+const main = async () => {
+  const graphQlEndpoints = {
+    TESTNET: mercuryGraphQLTestnet,
+    PUBLIC: mercuryGraphQLPubnet,
+  };
+
+  const graphQlCurrentDataEndpoints = {
+    TESTNET: mercuryGraphQLCurrentDataTestnet,
+    PUBLIC: mercuryGraphQLCurrentDataPubnet,
+  };
+
+  const backends = {
+    TESTNET: mercuryBackendTestnet,
+    PUBLIC: mercuryBackendPubnet,
+  };
+
+  const redis = new Redis({
+    connectionName: redisConnectionName,
+    host: hostname,
+    port: redisPort,
+    maxRetriesPerRequest: 1,
+  });
+
+  redis.on("error", (error: any) => {
+    logger.info("redis connection error", error);
+    throw new Error(error);
+  });
+
+  const checkNetwork = "PUBLIC";
+  // initial token and userID not needed for integrity checks
+  const integrityCheckMercurySession = {
+    renewClientMaker: buildRenewClientMaker(graphQlEndpoints),
+    backendClientMaker: buildBackendClientMaker(graphQlEndpoints),
+    currentDataClientMaker: buildCurrentDataClientMaker(
+      graphQlCurrentDataEndpoints
+    ),
+    backends,
+    credentials: {
+      TESTNET: {
+        email: mercuryEmailTestnet,
+        password: mercuryPasswordTestnet,
+      },
+      // need to set this to the integrity check accounts for Mercury to remove entries periodically
+      PUBLIC: {
+        email: mercuryIntegrityCheckEmail,
+        password: mercuryIntegrityCheckPass,
+      },
+    },
+  };
+
+  const integrityCheckMercuryClient = new MercuryClient(
+    integrityCheckMercurySession,
+    logger,
+    register,
+    {
+      mercuryErrorCounter,
+      rpcErrorCounter,
+      criticalError,
+    },
+    redis
+  );
+
+  const integrityCheckerClient = new IntegrityChecker(
+    logger,
+    integrityCheckMercuryClient,
+    redis,
+    register
+  );
+  await integrityCheckerClient.watchLedger(checkNetwork);
+};
+
+main().catch((e) => {
+  logger.error(e);
+});

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,23 +1,46 @@
 const path = require("path");
 const nodeExternals = require("webpack-node-externals");
-module.exports = {
-  entry: "./src/index.ts",
-  mode: "production",
-  target: "node",
-  output: {
-    path: path.resolve(__dirname, "build"),
-    filename: "index.js",
+module.exports = [
+  {
+    entry: "./src/index.ts",
+    mode: "production",
+    target: "node",
+    output: {
+      path: path.resolve(__dirname, "build"),
+      filename: "index.js",
+    },
+    resolve: {
+      extensions: [".ts", ".js"],
+    },
+    externals: [nodeExternals()],
+    module: {
+      rules: [
+        {
+          test: /\.([cm]?ts)$/,
+          use: ["ts-loader"],
+        },
+      ],
+    },
   },
-  resolve: {
-    extensions: [".ts", ".js"],
+  {
+    entry: "./src/service/integrity-checker/worker.ts",
+    mode: "production",
+    target: "node",
+    output: {
+      path: path.resolve(__dirname, "build"),
+      filename: "worker.js",
+    },
+    resolve: {
+      extensions: [".ts", ".js"],
+    },
+    externals: [nodeExternals()],
+    module: {
+      rules: [
+        {
+          test: /\.([cm]?ts)$/,
+          use: ["ts-loader"],
+        },
+      ],
+    },
   },
-  externals: [nodeExternals()],
-  module: {
-    rules: [
-      {
-        test: /\.([cm]?ts)$/,
-        use: ["ts-loader"],
-      },
-    ],
-  },
-};
+];


### PR DESCRIPTION
What
Adds worker module and moves integrity check to run in worker thread
Moves common helpers to helper files

Why
This will help keep the main thread clear for API usage while the integrity check runs in worker thread