### PR TITLE
[FEATURE] Optional timeout in gql client construction

### DIFF
--- a/src/helper/mercury.ts
+++ b/src/helper/mercury.ts
@@ -44,7 +44,8 @@ export const getUseMercury = async (
 };
 
 export const buildRenewClientMaker =
-  (endpoints: EndpointsMap) => (network: NetworkNames) => {
+  (endpoints: EndpointsMap, useTimeout = true) =>
+  (network: NetworkNames) => {
     if (!hasIndexerSupport(network)) {
       throw new Error(`network not currently supported: ${network}`);
     }
@@ -52,12 +53,13 @@ export const buildRenewClientMaker =
     return new Client({
       url: endpoints[network as MercurySupportedNetworks],
       exchanges: [fetchExchange],
-      fetch: fetchWithTimeout,
+      fetch: useTimeout ? fetchWithTimeout : fetch,
     });
   };
 
 export const buildBackendClientMaker =
-  (endpoints: EndpointsMap) => (network: NetworkNames, key: string) => {
+  (endpoints: EndpointsMap, useTimeout = true) =>
+  (network: NetworkNames, key: string) => {
     if (!hasIndexerSupport(network)) {
       throw new Error(`network not currently supported: ${network}`);
     }
@@ -65,7 +67,7 @@ export const buildBackendClientMaker =
     return new Client({
       url: `${endpoints[network as MercurySupportedNetworks]}`,
       exchanges: [fetchExchange],
-      fetch: fetchWithTimeout,
+      fetch: useTimeout ? fetchWithTimeout : fetch,
       fetchOptions: () => {
         return {
           headers: { authorization: `Bearer ${key}` },
@@ -75,7 +77,8 @@ export const buildBackendClientMaker =
   };
 
 export const buildCurrentDataClientMaker =
-  (endpoints: EndpointsMap) => (network: NetworkNames, key: string) => {
+  (endpoints: EndpointsMap, useTimeout = true) =>
+  (network: NetworkNames, key: string) => {
     if (!hasIndexerSupport(network)) {
       throw new Error(`network not currently supported: ${network}`);
     }
@@ -83,7 +86,7 @@ export const buildCurrentDataClientMaker =
     return new Client({
       url: `${endpoints[network as MercurySupportedNetworks]}`,
       exchanges: [fetchExchange],
-      fetch: fetchWithTimeout,
+      fetch: useTimeout ? fetchWithTimeout : fetch,
       fetchOptions: () => {
         return {
           headers: { authorization: `Bearer ${key}` },

--- a/src/service/integrity-checker/worker.ts
+++ b/src/service/integrity-checker/worker.ts
@@ -75,10 +75,11 @@ const main = async () => {
   const checkNetwork = "PUBLIC";
   // initial token and userID not needed for integrity checks
   const integrityCheckMercurySession = {
-    renewClientMaker: buildRenewClientMaker(graphQlEndpoints),
-    backendClientMaker: buildBackendClientMaker(graphQlEndpoints),
+    renewClientMaker: buildRenewClientMaker(graphQlEndpoints, false),
+    backendClientMaker: buildBackendClientMaker(graphQlEndpoints, false),
     currentDataClientMaker: buildCurrentDataClientMaker(
-      graphQlCurrentDataEndpoints
+      graphQlCurrentDataEndpoints,
+      false
     ),
     backends,
     credentials: {


### PR DESCRIPTION
What
Makes timeouts optional in the GraqhQL client makers.
Turns timeouts off for clients used during integrity checks.

Why
These timeouts were occasionally triggering a timeout during integrity checks when we get unlucky and hit an account that has a huge number of ops.
In practice, we don't care about the integrity checks resolving in under 5s or any reasonable amount of time as long as they resolve. We still use timeouts for clients used when serving user requests.