### PR TITLE
refactor addScanResults to use bulk scan

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node": ">=18.12.0"
   },
   "dependencies": {
-    "@blockaid/client": "^0.16.0",
+    "@blockaid/client": "^0.18.0",
     "@fastify/cors": "^9.0.1",
     "@fastify/helmet": "^11.1.1",
     "@fastify/rate-limit": "^9.1.0",

--- a/src/service/blockaid/index.ts
+++ b/src/service/blockaid/index.ts
@@ -109,7 +109,6 @@ export class BlockAidService {
         tokens: addressList,
         chain: "stellar",
       });
-      console.log(data);
       return { data, error: null };
     } catch (error) {
       this.logger.error(error);

--- a/src/service/blockaid/index.ts
+++ b/src/service/blockaid/index.ts
@@ -21,7 +21,7 @@ export class BlockAidService {
   constructor(
     blockAidClient: Blockaid,
     logger: Logger,
-    register: Prometheus.Registry
+    register: Prometheus.Registry,
   ) {
     this.blockAidClient = blockAidClient;
     this.logger = logger;
@@ -34,7 +34,7 @@ export class BlockAidService {
   }
 
   scanDapp = async (
-    url: string
+    url: string,
   ): Promise<{
     data: Blockaid.Site.SiteScanResponse | null;
     error: string | null;
@@ -80,7 +80,7 @@ export class BlockAidService {
   };
 
   scanAsset = async (
-    address: string
+    address: string,
   ): Promise<{
     data: Blockaid.Token.TokenScanResponse | null;
     error: string | null;
@@ -90,6 +90,26 @@ export class BlockAidService {
         address,
         chain: "stellar",
       });
+      return { data, error: null };
+    } catch (error) {
+      this.logger.error(error);
+      this.scanMissCounter.inc();
+      return { data: null, error: ERROR.UNABLE_TO_SCAN_ASSET };
+    }
+  };
+
+  scanAssetBulk = async (
+    addressList: string[],
+  ): Promise<{
+    data: Blockaid.TokenBulk.TokenBulkScanResponse | null;
+    error: string | null;
+  }> => {
+    try {
+      const data = await this.blockAidClient.tokenBulk.scan({
+        tokens: addressList,
+        chain: "stellar",
+      });
+      console.log(data);
       return { data, error: null };
     } catch (error) {
       this.logger.error(error);

--- a/yarn.lock
+++ b/yarn.lock
@@ -358,10 +358,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@blockaid/client@^0.16.0":
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/@blockaid/client/-/client-0.16.0.tgz#cfa4a8f2ec6308b186b89ed647e1c1a1c3f4527a"
-  integrity sha512-31LXA5nZ6dgh3ssAfPKvANvaRiKjY9nTzOac45DNbvDJ4S3nVmGNhphLYDxZ0i0Z0Vf+n7FnnTcXpjTV2UuY2g==
+"@blockaid/client@^0.18.0":
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/@blockaid/client/-/client-0.18.0.tgz#34a22b0e2266504531b61dc64adf993ffcddb3a9"
+  integrity sha512-XUjyEvAMKrbPFTK3+tMfkJZCoZ1D9pSGh2EywSMbYvLb9DFvSJAqWmX7AKZIl0Q0IOFBZTUKhGzjQrTgckuJZg==
   dependencies:
     "@types/node" "^18.11.18"
     "@types/node-fetch" "^2.6.4"


### PR DESCRIPTION
_What_
The Blockaid team has added the bulk asset scan endpoint to their SDK.

_Why_

This now uses 1 API request for all the assets a users has rather than O(n)

