### PR TITLE
[BUG] error case account balances scan

### DIFF
--- a/src/route/index.ts
+++ b/src/route/index.ts
@@ -345,9 +345,12 @@ export async function initApiServer(
                 blockaidConfig.useBlockaidAssetScanning,
               );
             } catch (e) {
-              data.balances = data.balances.map((bal: {}) => ({
-                ...bal,
+              data.balances = Object.keys(data.balances).map((key: string) => ({
+                ...data.balances[key],
                 isMalicious: false,
+                blockaidData: {
+                  ...defaultBenignResponse,
+                },
               }));
               logger.error(e);
             }
@@ -621,12 +624,10 @@ export async function initApiServer(
               return reply.code(500).send(ERROR.SERVER_ERROR);
             }
           }
-          return reply
-            .code(200)
-            .send({
-              data: { status: "miss" },
-              error: ERROR.SCAN_SITE_DISABLED,
-            });
+          return reply.code(200).send({
+            data: { status: "miss" },
+            error: ERROR.SCAN_SITE_DISABLED,
+          });
         },
       });
 


### PR DESCRIPTION
What
The catch for the blockaid scan part of this route flow did not properly set the base response with a `blockaidData` key for each balance.

Why
In the case of an error scanning through blockaid, the response shape returned is different from the expected response by clients. 