### PR TITLE
Allow optional "fetch_balance" parameter on /token-details route

### DIFF
--- a/src/helper/test-helper.ts
+++ b/src/helper/test-helper.ts
@@ -614,7 +614,7 @@ jest
       _pubKey: string,
       _contractId: string,
       _network: NetworkNames,
-      fetchBalance?: boolean,
+      shouldFetchBalance?: boolean,
     ): any => {
       const baseResponse = {
         name: "Test Contract",
@@ -622,7 +622,7 @@ jest
         symbol: "TST",
       };
 
-      if (fetchBalance) {
+      if (shouldFetchBalance) {
         return {
           ...baseResponse,
           balance: 1000000,

--- a/src/helper/test-helper.ts
+++ b/src/helper/test-helper.ts
@@ -618,14 +618,14 @@ jest
     ): any => {
       const baseResponse = {
         name: "Test Contract",
-        decimals: 7,
+        decimals: "7",
         symbol: "TST",
       };
 
       if (shouldFetchBalance) {
         return {
           ...baseResponse,
-          balance: 1000000,
+          balance: "1000000",
         };
       }
 

--- a/src/helper/test-helper.ts
+++ b/src/helper/test-helper.ts
@@ -610,12 +610,26 @@ const blockAidService = new BlockAidService(
 jest
   .spyOn(mockMercuryClient, "tokenDetails")
   .mockImplementation(
-    (..._args: Parameters<MercuryClient["tokenDetails"]>): any => {
-      return {
+    (
+      _pubKey: string,
+      _contractId: string,
+      _network: NetworkNames,
+      fetchBalance?: boolean,
+    ): any => {
+      const baseResponse = {
         name: "Test Contract",
         decimals: 7,
         symbol: "TST",
       };
+
+      if (fetchBalance) {
+        return {
+          ...baseResponse,
+          balance: 1000000,
+        };
+      }
+
+      return baseResponse;
     },
   );
 async function getDevServer(

--- a/src/route/index.test.ts
+++ b/src/route/index.test.ts
@@ -111,6 +111,63 @@ describe("API routes", () => {
       await server.close();
     });
   });
+  describe("/token-details/:contractId", () => {
+    it("can fetch token details for a contract ID with pub_key", async () => {
+      const contractId =
+        "CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP";
+      const server = await getDevServer();
+      const response = await fetch(
+        `http://localhost:${
+          (server?.server?.address() as any).port
+        }/api/v1/token-details/${contractId}?network=TESTNET&pub_key=${pubKey}`,
+      );
+      expect(response.status).toEqual(200);
+      register.clear();
+      await server.close();
+    });
+
+    it("can fetch token details with balance when should_fetch_balance=true", async () => {
+      const contractId =
+        "CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP";
+      const server = await getDevServer();
+      const response = await fetch(
+        `http://localhost:${
+          (server?.server?.address() as any).port
+        }/api/v1/token-details/${contractId}?network=TESTNET&pub_key=${pubKey}&should_fetch_balance=true`,
+      );
+      expect(response.status).toEqual(200);
+      register.clear();
+      await server.close();
+    });
+
+    it("rejects requests for invalid contract IDs", async () => {
+      const invalidContractId = "invalid";
+      const server = await getDevServer();
+      const response = await fetch(
+        `http://localhost:${
+          (server?.server?.address() as any).port
+        }/api/v1/token-details/${invalidContractId}?network=TESTNET&pub_key=${pubKey}`,
+      );
+      expect(response.status).toEqual(400);
+      register.clear();
+      await server.close();
+    });
+
+    it("rejects requests without pub_key parameter", async () => {
+      const contractId =
+        "CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP";
+      const server = await getDevServer();
+      const response = await fetch(
+        `http://localhost:${
+          (server?.server?.address() as any).port
+        }/api/v1/token-details/${contractId}?network=TESTNET`,
+      );
+      expect(response.status).toEqual(400);
+      register.clear();
+      await server.close();
+    });
+  });
+
   describe("/account-balances/:pubKey", () => {
     it("can fetch account balances for a pub key & contract IDs", async () => {
       const server = await getDevServer();

--- a/src/route/index.ts
+++ b/src/route/index.ts
@@ -399,6 +399,9 @@ export async function initApiServer(
                 type: "string",
                 validator: (qStr: string) => isNetwork(qStr),
               },
+              ["fetch_balance"]: {
+                type: "boolean",
+              },
             },
           },
         },
@@ -408,12 +411,13 @@ export async function initApiServer(
             Querystring: {
               ["pub_key"]: string;
               ["network"]: NetworkNames;
+              ["fetch_balance"]?: boolean;
             };
           }>,
           reply,
         ) => {
           const contractId = request.params["contractId"];
-          const { network, pub_key } = request.query;
+          const { network, pub_key, fetch_balance } = request.query;
 
           const skipSorobanPubnet = network === "PUBLIC" && !useSorobanPublic;
           if (skipSorobanPubnet) {
@@ -425,6 +429,7 @@ export async function initApiServer(
               pub_key,
               contractId,
               network,
+              fetch_balance,
             );
             reply.code(200).send(data);
           } catch (error) {

--- a/src/route/index.ts
+++ b/src/route/index.ts
@@ -399,9 +399,7 @@ export async function initApiServer(
                 type: "string",
                 validator: (qStr: string) => isNetwork(qStr),
               },
-              ["fetch_balance"]: {
-                type: "boolean",
-              },
+              ["should_fetch_balance"]: { type: "string" },
             },
           },
         },
@@ -411,13 +409,13 @@ export async function initApiServer(
             Querystring: {
               ["pub_key"]: string;
               ["network"]: NetworkNames;
-              ["fetch_balance"]?: boolean;
+              ["should_fetch_balance"]: string;
             };
           }>,
           reply,
         ) => {
           const contractId = request.params["contractId"];
-          const { network, pub_key, fetch_balance } = request.query;
+          const { network, pub_key, should_fetch_balance } = request.query;
 
           const skipSorobanPubnet = network === "PUBLIC" && !useSorobanPublic;
           if (skipSorobanPubnet) {
@@ -429,7 +427,7 @@ export async function initApiServer(
               pub_key,
               contractId,
               network,
-              fetch_balance,
+              should_fetch_balance === "true",
             );
             reply.code(200).send(data);
           } catch (error) {

--- a/src/service/mercury/helpers/transformers.ts
+++ b/src/service/mercury/helpers/transformers.ts
@@ -94,7 +94,7 @@ interface TokenDetails {
     name: string;
     symbol: string;
     decimals: string;
-    balance?: number;
+    balance?: string;
   };
 }
 

--- a/src/service/mercury/index.test.ts
+++ b/src/service/mercury/index.test.ts
@@ -60,12 +60,12 @@ describe("Mercury Service", () => {
       CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP: {
         name: "Test Token",
         symbol: "TST",
-        decimals: 7,
+        decimals: "7",
       },
       CBGTG7XFRY3L6OKAUTR6KGDKUXUQBX3YDJ3QFDYTGVMOM7VV4O7NCODG: {
         name: "Test Token 2",
         symbol: "TST",
-        decimals: 7,
+        decimals: "7",
       },
     };
 
@@ -460,9 +460,9 @@ describe("Mercury Service", () => {
 
     expect(response).toEqual({
       name: "Test Contract",
-      decimals: 7,
+      decimals: "7",
       symbol: "TST",
-      balance: 1000000,
+      balance: "1000000",
     });
   });
 
@@ -482,7 +482,7 @@ describe("Mercury Service", () => {
 
     expect(response).toEqual({
       name: "Test Contract",
-      decimals: 7,
+      decimals: "7",
       symbol: "TST",
     });
   });
@@ -502,7 +502,7 @@ describe("Mercury Service", () => {
 
     expect(response).toEqual({
       name: "Test Contract",
-      decimals: 7,
+      decimals: "7",
       symbol: "TST",
     });
   });
@@ -523,9 +523,9 @@ describe("Mercury Service", () => {
 
     expect(response).toEqual({
       name: "Test Contract",
-      decimals: 7,
+      decimals: "7",
       symbol: "TST",
-      balance: 1000000,
+      balance: "1000000",
     });
   });
 });

--- a/src/service/mercury/index.test.ts
+++ b/src/service/mercury/index.test.ts
@@ -440,4 +440,70 @@ describe("Mercury Service", () => {
     );
     expect(wBtcBalances).toHaveLength(1);
   });
+  it("can get token details with balance", async () => {
+    const testPubKey =
+      "GCGORBD5DB4JDIKVIA536CJE3EWMWZ6KBUBWZWRQM7Y3NHFRCLOKYVAL";
+    const testContractId =
+      "CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP";
+    const testNetwork = "TESTNET" as const;
+
+    jest
+      .spyOn(SorobanRpcHelper, "getTokenBalance")
+      .mockReturnValue(Promise.resolve(1000000));
+
+    const response = await mockMercuryClient.tokenDetails(
+      testPubKey,
+      testContractId,
+      testNetwork,
+      true,
+    );
+
+    expect(response).toEqual({
+      name: "Test Contract",
+      decimals: 7,
+      symbol: "TST",
+      balance: 1000000,
+    });
+  });
+
+  it("can get token details without balance when fetchBalance is false", async () => {
+    const testPubKey =
+      "GCGORBD5DB4JDIKVIA536CJE3EWMWZ6KBUBWZWRQM7Y3NHFRCLOKYVAL";
+    const testContractId =
+      "CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP";
+    const testNetwork = "TESTNET" as const;
+
+    const response = await mockMercuryClient.tokenDetails(
+      testPubKey,
+      testContractId,
+      testNetwork,
+      false,
+    );
+
+    expect(response).toEqual({
+      name: "Test Contract",
+      decimals: 7,
+      symbol: "TST",
+    });
+  });
+
+  it("can get token details without balance when fetchBalance is undefined", async () => {
+    const testPubKey =
+      "GCGORBD5DB4JDIKVIA536CJE3EWMWZ6KBUBWZWRQM7Y3NHFRCLOKYVAL";
+    const testContractId =
+      "CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP";
+    const testNetwork = "TESTNET" as const;
+
+    const response = await mockMercuryClient.tokenDetails(
+      testPubKey,
+      testContractId,
+      testNetwork,
+    );
+
+    expect(response).toEqual({
+      name: "Test Contract",
+      decimals: 7,
+      symbol: "TST",
+    });
+  });
 });

--- a/src/service/mercury/index.test.ts
+++ b/src/service/mercury/index.test.ts
@@ -466,7 +466,7 @@ describe("Mercury Service", () => {
     });
   });
 
-  it("can get token details without balance when fetchBalance is false", async () => {
+  it("can get token details without balance when shouldFetchBalance is false", async () => {
     const testPubKey =
       "GCGORBD5DB4JDIKVIA536CJE3EWMWZ6KBUBWZWRQM7Y3NHFRCLOKYVAL";
     const testContractId =
@@ -487,7 +487,7 @@ describe("Mercury Service", () => {
     });
   });
 
-  it("can get token details without balance when fetchBalance is undefined", async () => {
+  it("can get token details without balance when shouldFetchBalance is undefined", async () => {
     const testPubKey =
       "GCGORBD5DB4JDIKVIA536CJE3EWMWZ6KBUBWZWRQM7Y3NHFRCLOKYVAL";
     const testContractId =
@@ -504,6 +504,28 @@ describe("Mercury Service", () => {
       name: "Test Contract",
       decimals: 7,
       symbol: "TST",
+    });
+  });
+
+  it("returns token details with balance when shouldFetchBalance is true", async () => {
+    const testPubKey =
+      "GCGORBD5DB4JDIKVIA536CJE3EWMWZ6KBUBWZWRQM7Y3NHFRCLOKYVAL";
+    const testContractId =
+      "CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP";
+    const testNetwork = "TESTNET" as const;
+
+    const response = await mockMercuryClient.tokenDetails(
+      testPubKey,
+      testContractId,
+      testNetwork,
+      true,
+    );
+
+    expect(response).toEqual({
+      name: "Test Contract",
+      decimals: 7,
+      symbol: "TST",
+      balance: 1000000,
     });
   });
 });

--- a/src/service/mercury/index.ts
+++ b/src/service/mercury/index.ts
@@ -423,7 +423,7 @@ export class MercuryClient {
     pubKey: string,
     contractId: string,
     network: NetworkNames,
-    fetchBalance: boolean = false,
+    shouldFetchBalance: boolean = false,
   ): Promise<{
     name: string;
     symbol: string;
@@ -461,7 +461,7 @@ export class MercuryClient {
       );
 
       let balance: number | undefined;
-      if (fetchBalance) {
+      if (shouldFetchBalance) {
         const balanceBuilder = await getTxBuilder(pubKey, network, server);
         const Sdk = getSdk(StellarSdkNext.Networks[network]);
         const params = [new Sdk.Address(pubKey).toScVal()];

--- a/src/service/mercury/index.ts
+++ b/src/service/mercury/index.ts
@@ -121,7 +121,7 @@ export class MercuryClient {
       rpcErrorCounter: Prometheus.Counter<"rpc">;
       criticalError: Prometheus.Counter<"message">;
     },
-    redisClient?: Redis
+    redisClient?: Redis,
   ) {
     this.mercurySession = mercurySession;
     this.logger = logger;
@@ -161,7 +161,7 @@ export class MercuryClient {
       const creds = this.mercurySession.credentials[network];
       const { data, error } = await renewClient.mutation(
         mutation.authenticate,
-        creds
+        creds,
       );
 
       if (error) {
@@ -184,7 +184,7 @@ export class MercuryClient {
   renewAndRetry = async <T>(
     method: () => Promise<T>,
     network: NetworkNames,
-    retryCount?: number
+    retryCount?: number,
   ): Promise<T> => {
     try {
       return await method();
@@ -212,7 +212,7 @@ export class MercuryClient {
   tokenSubscription = async (
     contractId: string,
     pubKey: string,
-    network: NetworkNames
+    network: NetworkNames,
   ) => {
     const Sdk = getSdk(StellarSdkNext.Networks[network]);
     if (!hasIndexerSupport(network)) {
@@ -258,12 +258,12 @@ export class MercuryClient {
         const { data: transferFromRes } = await axios.post(
           eventsURL,
           transferToSub,
-          config
+          config,
         );
         const { data: transferToRes } = await axios.post(
           eventsURL,
           transferFromSub,
-          config
+          config,
         );
         const { data: mintRes } = await axios.post(eventsURL, mintSub, config);
 
@@ -302,7 +302,7 @@ export class MercuryClient {
   accountSubscription = async (
     pubKey: string,
     network: NetworkNames,
-    epochs: number = 6
+    epochs: number = 6,
   ) => {
     if (!hasIndexerSupport(network)) {
       return {
@@ -328,7 +328,7 @@ export class MercuryClient {
             this.mercurySession.backends[network as MercurySupportedNetworks]
           }/account`,
           { publickey: pubKey, hydrate: true, epochs },
-          config
+          config,
         );
         return data;
       };
@@ -336,7 +336,7 @@ export class MercuryClient {
       const data = await this.renewAndRetry(
         subscribe,
         network,
-        DEFAULT_RETRY_AMOUNT
+        DEFAULT_RETRY_AMOUNT,
       );
 
       return {
@@ -360,7 +360,7 @@ export class MercuryClient {
   tokenBalanceSubscription = async (
     contractId: string,
     pubKey: string,
-    network: NetworkNames
+    network: NetworkNames,
   ) => {
     if (!hasIndexerSupport(network)) {
       throw new Error(`network not currently supported: ${network}`);
@@ -394,7 +394,7 @@ export class MercuryClient {
       const data = await this.renewAndRetry(
         getData,
         network,
-        DEFAULT_RETRY_AMOUNT
+        DEFAULT_RETRY_AMOUNT,
       );
 
       if (this.redisClient) {
@@ -422,8 +422,14 @@ export class MercuryClient {
   tokenDetails = async (
     pubKey: string,
     contractId: string,
-    network: NetworkNames
-  ): Promise<{ name: string; symbol: string; decimals: string }> => {
+    network: NetworkNames,
+    fetchBalance: boolean = false,
+  ): Promise<{
+    name: string;
+    symbol: string;
+    decimals: string;
+    balance?: number;
+  }> => {
     try {
       const compositeKey = `${network}__${contractId}`;
       // get from cache if we have them, otherwise go to ledger and cache
@@ -440,7 +446,7 @@ export class MercuryClient {
         contractId,
         server,
         decimalsBuilder,
-        network
+        network,
       );
 
       const nameBuilder = await getTxBuilder(pubKey, network, server);
@@ -451,23 +457,35 @@ export class MercuryClient {
         contractId,
         server,
         symbolsBuilder,
-        network
+        network,
       );
+
+      let balance: number | undefined;
+      if (fetchBalance) {
+        const balanceBuilder = await getTxBuilder(pubKey, network, server);
+        const Sdk = getSdk(StellarSdkNext.Networks[network]);
+        const params = [new Sdk.Address(pubKey).toScVal()];
+        balance = await getTokenBalance(
+          contractId,
+          params,
+          server,
+          balanceBuilder,
+          network,
+        );
+      }
+
       const tokenDetails = {
         name,
         decimals,
         symbol,
+        ...(balance !== undefined && { balance }),
       };
 
       if (this.redisClient) {
         await this.redisClient.set(compositeKey, JSON.stringify(tokenDetails));
       }
 
-      return {
-        name,
-        decimals,
-        symbol,
-      };
+      return tokenDetails;
     } catch (error) {
       if (error instanceof Error) {
         throw error;
@@ -526,7 +544,7 @@ export class MercuryClient {
         const { error } = await this.accountSubscription(pubKey, network);
         if (!error) {
           this.logger.info(
-            `Subscribed to missing account sub - ${pubKey} - ${network}`
+            `Subscribed to missing account sub - ${pubKey} - ${network}`,
           );
         }
         throw new Error(ERROR.MISSING_SUB_FOR_PUBKEY);
@@ -538,7 +556,7 @@ export class MercuryClient {
 
       const urqlClient = this.mercurySession.backendClientMaker(
         network,
-        this.tokens[network]
+        this.tokens[network],
       );
       const getData = async () => {
         const data = await urqlClient.query(query.getAccountHistory, {
@@ -568,7 +586,7 @@ export class MercuryClient {
   getAccountHistory = async (
     pubKey: string,
     network: NetworkNames,
-    useMercury: boolean
+    useMercury: boolean,
   ) => {
     if (hasIndexerSupport(network) && useMercury) {
       const response = await this.getAccountHistoryMercury(pubKey, network);
@@ -587,7 +605,7 @@ export class MercuryClient {
 
     const horizonResponse = await this.getAccountHistoryHorizon(
       pubKey,
-      network
+      network,
     );
     return horizonResponse;
   };
@@ -595,7 +613,7 @@ export class MercuryClient {
   getTokenBalancesSorobanRPC = async (
     pubKey: string,
     contractIds: string[],
-    network: NetworkNames
+    network: NetworkNames,
   ) => {
     const Sdk = getSdk(StellarSdk.Networks[network]);
     const networkUrl = SOROBAN_RPC_URLS[network];
@@ -616,7 +634,7 @@ export class MercuryClient {
           params,
           server,
           builder,
-          network
+          network,
         );
         const tokenDetails = await this.tokenDetails(pubKey, id, network);
         balances.push({
@@ -634,7 +652,7 @@ export class MercuryClient {
       const isSac = isSacContract(
         balance.name,
         balance.id,
-        StellarSdk.Networks[network]
+        StellarSdk.Networks[network],
       );
       const issuerKey = isSac ? balance.name.split(":")[1] : balance.id;
 
@@ -697,7 +715,7 @@ export class MercuryClient {
   getAccountBalancesMercury = async (
     pubKey: string,
     contractIds: string[],
-    network: NetworkNames
+    network: NetworkNames,
   ) => {
     try {
       if (!hasIndexerSupport(network)) {
@@ -720,20 +738,20 @@ export class MercuryClient {
         const urqlClientCurrentData =
           this.mercurySession.currentDataClientMaker(
             network,
-            this.tokens[network]
+            this.tokens[network],
           );
 
         const responseCurrentData = await urqlClientCurrentData.query(
           query.getCurrentDataAccountBalances(
             pubKey,
             this.tokenBalanceKey(pubKey, network),
-            contractIds
+            contractIds,
           ),
-          {}
+          {},
         );
 
         const errorMessageCurrentData = getGraphQlError(
-          responseCurrentData.error
+          responseCurrentData.error,
         );
         if (errorMessageCurrentData) {
           throw new Error(errorMessageCurrentData);
@@ -746,7 +764,7 @@ export class MercuryClient {
         responseCurrentData,
         tokenDetails,
         contractIds,
-        StellarSdk.Networks[network]
+        StellarSdk.Networks[network],
       );
 
       return {
@@ -765,13 +783,13 @@ export class MercuryClient {
     pubKey: string,
     contractIds: string[],
     network: NetworkNames,
-    useMercury: boolean
+    useMercury: boolean,
   ) => {
     if (hasIndexerSupport(network) && useMercury) {
       const response = await this.getAccountBalancesMercury(
         pubKey,
         contractIds,
-        network
+        network,
       );
 
       // if Mercury returns an error, fallback to the RPCs
@@ -811,7 +829,7 @@ export class MercuryClient {
     } catch (error) {
       this.logger.error(error);
       this.logger.error(
-        `failed to fetch classic balances from Horizon: ${pubKey}, ${network}`
+        `failed to fetch classic balances from Horizon: ${pubKey}, ${network}`,
       );
       if (error && typeof error === "object" && "message" in error) {
         const err = JSON.parse(error.message as string);
@@ -831,13 +849,13 @@ export class MercuryClient {
       tokenBalances = await this.getTokenBalancesSorobanRPC(
         pubKey,
         contractIds,
-        network
+        network,
       );
     } catch (error) {
       rpcError = error;
       this.logger.error(error);
       this.logger.error(
-        `failed to fetch token balances from Soroban RPC: ${pubKey}, ${network}`
+        `failed to fetch token balances from Soroban RPC: ${pubKey}, ${network}`,
       );
       this.rpcErrorCounter
         .labels({
@@ -874,7 +892,7 @@ export class MercuryClient {
 
   getAccountSubForPubKey = async (
     publicKey: string,
-    network: NetworkNames
+    network: NetworkNames,
   ): Promise<{ publickey: string }[]> => {
     if (!hasIndexerSupport(network)) {
       throw new Error(`network not currently supported: ${network}`);
@@ -887,11 +905,11 @@ export class MercuryClient {
       const getData = async () => {
         const urqlClient = this.mercurySession.backendClientMaker(
           network,
-          this.tokens[network]
+          this.tokens[network],
         );
         const response = await urqlClient.query(
           query.getAccountSubForPubKey(publicKey),
-          {}
+          {},
         );
 
         const errorMessage = getGraphQlError(response.error);
@@ -912,7 +930,7 @@ export class MercuryClient {
   getTokenBalanceSub = async (
     publicKey: string,
     contractId: string,
-    network: NetworkNames
+    network: NetworkNames,
   ) => {
     if (!hasIndexerSupport(network)) {
       throw new Error(`network not currently supported: ${network}`);
@@ -924,14 +942,14 @@ export class MercuryClient {
       const getData = async () => {
         const urqlClient = this.mercurySession.backendClientMaker(
           network,
-          this.tokens[network]
+          this.tokens[network],
         );
         const response = await urqlClient.query(
           query.getTokenBalanceSub(
             contractId,
-            this.tokenBalanceKey(publicKey, network)
+            this.tokenBalanceKey(publicKey, network),
           ),
-          {}
+          {},
         );
 
         const errorMessage = getGraphQlError(response.error);
@@ -966,7 +984,7 @@ export class MercuryClient {
           `${
             this.mercurySession.backends[network as MercurySupportedNetworks]
           }/hydrations/${hydrationId}`,
-          config
+          config,
         );
         return data;
       };
@@ -974,7 +992,7 @@ export class MercuryClient {
       const data = await this.renewAndRetry(
         subscribe,
         network,
-        DEFAULT_RETRY_AMOUNT
+        DEFAULT_RETRY_AMOUNT,
       );
       return data;
     } catch (error) {

--- a/src/service/mercury/index.ts
+++ b/src/service/mercury/index.ts
@@ -428,7 +428,7 @@ export class MercuryClient {
     name: string;
     symbol: string;
     decimals: string;
-    balance?: number;
+    balance?: string;
   }> => {
     try {
       const compositeKey = `${network}__${contractId}`;
@@ -460,18 +460,19 @@ export class MercuryClient {
         network,
       );
 
-      let balance: number | undefined;
+      let balance: string | undefined;
       if (shouldFetchBalance) {
         const balanceBuilder = await getTxBuilder(pubKey, network, server);
         const Sdk = getSdk(StellarSdkNext.Networks[network]);
         const params = [new Sdk.Address(pubKey).toScVal()];
-        balance = await getTokenBalance(
+        const rawBalance = await getTokenBalance(
           contractId,
           params,
           server,
           balanceBuilder,
           network,
         );
+        balance = rawBalance.toString();
       }
 
       const tokenDetails = {


### PR DESCRIPTION
Related: https://github.com/orgs/stellar/projects/58/views/2?pane=issue&itemId=80122477&issue=stellar%7Cfreighter%7C1646

Given the new ["Add Token" API](https://github.com/stellar/freighter/pull/1815) we are implementing on freighter's extension we'll need to return the token balance along with its other details in order to display it on the popup's UI (see [comments](https://github.com/stellar/freighter/pull/1815#discussion_r1941714567)) so users are aware of the new balance info.