### PR TITLE
Only use cache for static token details

### DIFF
--- a/src/route/index.test.ts
+++ b/src/route/index.test.ts
@@ -14,6 +14,7 @@ import { Networks } from "stellar-sdk-next";
 import { SOROBAN_RPC_URLS } from "../helper/soroban-rpc";
 import { ERROR } from "../helper/error";
 import * as StellarHelpers from "../helper/stellar";
+import * as SorobanRpcHelper from "../helper/soroban-rpc/token";
 
 jest.mock("@blockaid/client", () => {
   return class Blockaid {
@@ -136,6 +137,77 @@ describe("API routes", () => {
         }/api/v1/token-details/${contractId}?network=TESTNET&pub_key=${pubKey}&should_fetch_balance=true`,
       );
       expect(response.status).toEqual(200);
+      register.clear();
+      await server.close();
+    });
+
+    it("uses redis cache for static token details when should_fetch_balance=false", async () => {
+      const contractId =
+        "CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP";
+      const server = await getDevServer();
+
+      // First request should cache the static details
+      const response1 = await fetch(
+        `http://localhost:${
+          (server?.server?.address() as any).port
+        }/api/v1/token-details/${contractId}?network=TESTNET&pub_key=${pubKey}`,
+      );
+      const data1 = await response1.json();
+      expect(response1.status).toEqual(200);
+
+      // Second request should use cached data
+      const response2 = await fetch(
+        `http://localhost:${
+          (server?.server?.address() as any).port
+        }/api/v1/token-details/${contractId}?network=TESTNET&pub_key=${pubKey}`,
+      );
+      const data2 = await response2.json();
+      expect(response2.status).toEqual(200);
+
+      // Both responses should match
+      expect(data1).toEqual(data2);
+
+      register.clear();
+      await server.close();
+    });
+
+    it("uses redis cache for static token details but fetches fresh balance when should_fetch_balance=true", async () => {
+      const contractId =
+        "CCWAMYJME4H5CKG7OLXGC2T4M6FL52XCZ3OQOAV6LL3GLA4RO4WH3ASP";
+      const server = await getDevServer();
+
+      // First request should cache the static details
+      const response1 = await fetch(
+        `http://localhost:${
+          (server?.server?.address() as any).port
+        }/api/v1/token-details/${contractId}?network=TESTNET&pub_key=${pubKey}&should_fetch_balance=true`,
+      );
+      const data1 = await response1.json();
+      expect(response1.status).toEqual(200);
+
+      // Mock a payment that changes the balance
+      jest
+        .spyOn(SorobanRpcHelper, "getTokenBalance")
+        .mockReturnValueOnce(Promise.resolve(2000000));
+
+      // Second request should use cached static data but fetch fresh balance
+      const response2 = await fetch(
+        `http://localhost:${
+          (server?.server?.address() as any).port
+        }/api/v1/token-details/${contractId}?network=TESTNET&pub_key=${pubKey}&should_fetch_balance=true`,
+      );
+      const data2 = await response2.json();
+      expect(response2.status).toEqual(200);
+
+      // Static details should match
+      expect(data1.name).toEqual(data2.name);
+      expect(data1.symbol).toEqual(data2.symbol);
+      expect(data1.decimals).toEqual(data2.decimals);
+
+      // Balance should be different after payment
+      expect(data1.balance).toBe("1000000"); // Initial balance from mock
+      expect(data2.balance).toBe("2000000"); // New balance after payment
+
       register.clear();
       await server.close();
     });

--- a/src/service/mercury/index.ts
+++ b/src/service/mercury/index.ts
@@ -493,11 +493,6 @@ export class MercuryClient {
         symbol,
       };
 
-      const tokenDetails = {
-        ...staticTokenDetails,
-        ...(balance !== undefined && { balance }),
-      };
-
       // Only cache the static token details, not the balance since it changes over time
       if (this.redisClient) {
         await this.redisClient.set(
@@ -506,7 +501,10 @@ export class MercuryClient {
         );
       }
 
-      return tokenDetails;
+      return {
+        ...staticTokenDetails,
+        ...(balance !== undefined && { balance }),
+      };
     } catch (error) {
       if (error instanceof Error) {
         throw error;

--- a/src/service/mercury/index.ts
+++ b/src/service/mercury/index.ts
@@ -431,13 +431,13 @@ export class MercuryClient {
     balance?: string;
   }> => {
     try {
-      let balance: string | undefined;
-      let server: StellarSdkNext.rpc.Server | undefined;
+      const server = await getServer(network);
       const compositeKey = `${network}__${contractId}`;
+
+      let balance: string | undefined;
 
       // balance can change over time, so we need to fetch it fresh each time
       if (shouldFetchBalance) {
-        server = await getServer(network);
         const balanceBuilder = await getTxBuilder(pubKey, network, server);
         const Sdk = getSdk(StellarSdkNext.Networks[network]);
         const params = [new Sdk.Address(pubKey).toScVal()];
@@ -461,10 +461,6 @@ export class MercuryClient {
             ...(balance !== undefined && { balance }),
           };
         }
-      }
-
-      if (!server) {
-        server = await getServer(network);
       }
 
       // we need a builder per operation, 1 op per tx in Soroban


### PR DESCRIPTION
Related: https://github.com/stellar/freighter-backend/pull/204

This PR makes sure to cache only the static token details, and when the balance is requested (`should_fetch_balance=true`) it should always fetch the latest balance amount but still fetch and merge the cached static token details if any to make the request more performant.