### PR TITLE
Pass RPC URLs as env variables

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,12 @@ export interface PriceConfig {
   usdReceiveValue: number;
 }
 
+export interface StellarRpcConfig {
+  freighterRpcPubnetUrl: string;
+  freighterRpcTestnetUrl: string;
+  freighterRpcFuturenetUrl: string;
+}
+
 export function buildConfig(config: Record<string, string | undefined>) {
   const configKeys = Object.keys(config);
   const missingKeys = [] as string[];
@@ -76,6 +82,19 @@ export function buildConfig(config: Record<string, string | undefined>) {
     disableTokenPrices:
       config.DISABLE_TOKEN_PRICES === "true" ||
       process.env.DISABLE_TOKEN_PRICES === "true",
+    stellarRpcConfig: <StellarRpcConfig>{
+      freighterRpcPubnetUrl:
+        config.FREIGHTER_RPC_PUBNET_URL ||
+        process.env.FREIGHTER_RPC_PUBNET_URL!,
+      freighterRpcTestnetUrl:
+        config.FREIGHTER_RPC_TESTNET_URL ||
+        process.env.FREIGHTER_RPC_TESTNET_URL ||
+        "https://soroban-testnet.stellar.org/",
+      freighterRpcFuturenetUrl:
+        config.FREIGHTER_RPC_FUTURENET_URL ||
+        process.env.FREIGHTER_RPC_FUTURENET_URL ||
+        "https://rpc-futurenet.stellar.org/",
+    },
     priceConfig: <PriceConfig>{
       batchUpdateDelayMs:
         Number(config.PRICE_BATCH_UPDATE_DELAY_MS) ||

--- a/src/helper/soroban-rpc/index.test.ts
+++ b/src/helper/soroban-rpc/index.test.ts
@@ -75,7 +75,18 @@ describe("Soroban RPC helpers", () => {
         return Promise.resolve({ result: { notDefinitions: {} }, error: null });
       });
 
-      const isSep41 = await getIsTokenSpec("contractId", "TESTNET", testLogger);
+      const mockConfig = {
+        freighterRpcPubnetUrl: "http://mock-pubnet",
+        freighterRpcTestnetUrl: "http://mock-testnet",
+        freighterRpcFuturenetUrl: "http://mock-futurenet",
+      };
+
+      const isSep41 = await getIsTokenSpec(
+        "contractId",
+        "TESTNET",
+        testLogger,
+        mockConfig,
+      );
 
       expect(isSep41).toBeFalsy();
     });

--- a/src/helper/soroban-rpc/token.ts
+++ b/src/helper/soroban-rpc/token.ts
@@ -4,6 +4,7 @@ import { NetworkNames } from "../validate";
 import { Logger } from "pino";
 import { getSdk } from "../stellar";
 import { getContractSpec, getServer, simulateTx } from "./network";
+import { StellarRpcConfig } from "../../config";
 
 // https://github.com/stellar/soroban-examples/blob/main/token/src/contract.rs
 enum SorobanTokenInterface {
@@ -299,9 +300,15 @@ const getIsTokenSpec = async (
   contractId: string,
   network: NetworkNames,
   logger: Logger,
+  stellarRpcConfig: StellarRpcConfig,
 ) => {
   try {
-    const spec = await getContractSpec(contractId, network, logger);
+    const spec = await getContractSpec(
+      contractId,
+      network,
+      logger,
+      stellarRpcConfig,
+    );
     if (spec.error) {
       throw new Error(spec.error);
     }
@@ -329,12 +336,14 @@ const isTokenSpec = (spec: Record<string, any>) => {
 const isSacContractExecutable = async (
   contractId: string,
   network: NetworkNames,
+  stellarRpcConfig: StellarRpcConfig,
 ) => {
   // verify the contract executable in the instance entry
   // The SAC has a unique contract executable type
   const Sdk = getSdk(StellarSdkNext.Networks[network]);
   const { xdr } = Sdk;
-  const server = await getServer(network);
+
+  const server = await getServer(network, stellarRpcConfig);
   const instance = new Sdk.Contract(contractId).getFootprint();
   const ledgerKeyContractCode = instance.toXDR("base64");
 

--- a/src/helper/test-helper.ts
+++ b/src/helper/test-helper.ts
@@ -11,7 +11,7 @@ import { NetworkNames } from "./validate";
 import { hasIndexerSupport } from "./mercury";
 import { BlockAidService } from "../service/blockaid";
 import { PriceClient } from "../service/prices";
-import { PriceConfig } from "../config";
+import { PriceConfig, StellarRpcConfig } from "../config";
 
 export const TEST_SOROBAN_TX =
   "AAAAAgAAAACM6IR9GHiRoVVAO78JJNksy2fKDQNs2jBn8bacsRLcrDucaFsAAAWIAAAAMQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAGAAAAAAAAAABHkEVdJ+UfDnWpBr/qF582IEoDQ0iW0WPzO9CEUdvvh8AAAAIdHJhbnNmZXIAAAADAAAAEgAAAAAAAAAAjOiEfRh4kaFVQDu/CSTZLMtnyg0DbNowZ/G2nLES3KwAAAASAAAAAAAAAADoFl2ACT9HZkbCeuaT9MAIdStpdf58wM3P24nl738AnQAAAAoAAAAAAAAAAAAAAAAAAAAFAAAAAQAAAAAAAAAAAAAAAR5BFXSflHw51qQa/6hefNiBKA0NIltFj8zvQhFHb74fAAAACHRyYW5zZmVyAAAAAwAAABIAAAAAAAAAAIzohH0YeJGhVUA7vwkk2SzLZ8oNA2zaMGfxtpyxEtysAAAAEgAAAAAAAAAA6BZdgAk/R2ZGwnrmk/TACHUraXX+fMDNz9uJ5e9/AJ0AAAAKAAAAAAAAAAAAAAAAAAAABQAAAAAAAAABAAAAAAAAAAIAAAAGAAAAAR5BFXSflHw51qQa/6hefNiBKA0NIltFj8zvQhFHb74fAAAAFAAAAAEAAAAHa35L+/RxV6EuJOVk78H5rCN+eubXBWtsKrRxeLnnpRAAAAACAAAABgAAAAEeQRV0n5R8OdakGv+oXnzYgSgNDSJbRY/M70IRR2++HwAAABAAAAABAAAAAgAAAA8AAAAHQmFsYW5jZQAAAAASAAAAAAAAAACM6IR9GHiRoVVAO78JJNksy2fKDQNs2jBn8bacsRLcrAAAAAEAAAAGAAAAAR5BFXSflHw51qQa/6hefNiBKA0NIltFj8zvQhFHb74fAAAAEAAAAAEAAAACAAAADwAAAAdCYWxhbmNlAAAAABIAAAAAAAAAAOgWXYAJP0dmRsJ65pP0wAh1K2l1/nzAzc/bieXvfwCdAAAAAQBkcwsAACBwAAABKAAAAAAAAB1kAAAAAA==";
@@ -600,6 +600,12 @@ const mockPriceConfig = {
 } as PriceConfig;
 const mockPriceClient = new PriceClient(testLogger, mockPriceConfig);
 
+const mockStellarRpcConfig = {
+  freighterRpcPubnetUrl: "https://rpc-pubnet.stellar.org",
+  freighterRpcTestnetUrl: "https://rpc-testnet.stellar.org",
+  freighterRpcFuturenetUrl: "https://rpc-futurenet.stellar.org",
+} as StellarRpcConfig;
+
 const mockMercuryClient = new MercuryClient(
   mercurySession,
   testLogger,
@@ -609,6 +615,7 @@ const mockMercuryClient = new MercuryClient(
     rpcErrorCounter,
     criticalError,
   },
+  mockStellarRpcConfig,
 );
 jest.mock("@blockaid/client", () => {
   return class Blockaid {};
@@ -658,6 +665,7 @@ async function getDevServer(
     coinbaseApiSecret: "coinbaseApiSecret",
   },
   priceConfig = mockPriceConfig,
+  stellarRpcConfig = mockStellarRpcConfig,
 ) {
   register.clear();
 
@@ -673,6 +681,7 @@ async function getDevServer(
     blockaidConfig,
     coinbaseConfig,
     priceConfig,
+    stellarRpcConfig,
   );
 
   await server.listen();

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,6 +149,7 @@ async function main() {
       rpcErrorCounter,
       criticalError,
     },
+    conf.stellarRpcConfig,
     redis,
   );
 
@@ -169,6 +170,7 @@ async function main() {
     conf.blockaidConfig,
     conf.coinbaseConfig,
     conf.priceConfig,
+    conf.stellarRpcConfig,
     redis,
   );
   const metricsServer = await initMetricsServer(register, redis);
@@ -260,6 +262,7 @@ async function main() {
           redisConnectionName: conf.redisConnectionName,
           redisPort: conf.redisPort,
           sentryKey: conf.sentryKey,
+          stellarRpcConfig: conf.stellarRpcConfig,
         },
       };
       const integrityCheckWorker = new Worker("./build/worker.js", workerData);

--- a/src/route/index.test.ts
+++ b/src/route/index.test.ts
@@ -10,10 +10,17 @@ import { transformAccountHistory } from "../service/mercury/helpers/transformers
 import { query } from "../service/mercury/queries";
 import { defaultBenignResponse } from "../service/blockaid/helpers/addScanResults";
 import { Networks } from "stellar-sdk-next";
-import { SOROBAN_RPC_URLS } from "../helper/soroban-rpc";
 import { ERROR } from "../helper/error";
 import * as StellarHelpers from "../helper/stellar";
 import * as OnrampHelpers from "../helper/onramp";
+import { getStellarRpcUrls } from "../helper/soroban-rpc";
+import { StellarRpcConfig } from "../config";
+
+const mockStellarRpcConfig = {
+  freighterRpcPubnetUrl: "https://rpc-pubnet.stellar.org",
+  freighterRpcTestnetUrl: "https://rpc-testnet.stellar.org",
+  freighterRpcFuturenetUrl: "https://rpc-futurenet.stellar.org",
+} as StellarRpcConfig;
 
 jest.mock("@blockaid/client", () => {
   return class Blockaid {
@@ -867,7 +874,7 @@ describe("API routes", () => {
         },
         body: JSON.stringify({
           xdr: TEST_SOROBAN_TX,
-          network_url: SOROBAN_RPC_URLS.TESTNET,
+          network_url: getStellarRpcUrls(mockStellarRpcConfig).TESTNET,
           network_passphrase: Networks.TESTNET,
         }),
       };

--- a/src/service/integrity-checker/worker.ts
+++ b/src/service/integrity-checker/worker.ts
@@ -32,6 +32,7 @@ const {
   redisConnectionName,
   redisPort,
   sentryKey,
+  stellarRpcConfig,
 } = workerData;
 
 const main = async () => {
@@ -41,7 +42,7 @@ const main = async () => {
 
   if (!sentryKey || !sentryClient) {
     throw new Error(
-      `Sentry misconfiguration, dsn: ${sentryKey}, client: ${sentryClient}`
+      `Sentry misconfiguration, dsn: ${sentryKey}, client: ${sentryClient}`,
     );
   }
 
@@ -79,7 +80,7 @@ const main = async () => {
     backendClientMaker: buildBackendClientMaker(graphQlEndpoints, false),
     currentDataClientMaker: buildCurrentDataClientMaker(
       graphQlCurrentDataEndpoints,
-      false
+      false,
     ),
     backends,
     credentials: {
@@ -104,14 +105,15 @@ const main = async () => {
       rpcErrorCounter,
       criticalError,
     },
-    redis
+    stellarRpcConfig,
+    redis,
   );
 
   const integrityCheckerClient = new IntegrityChecker(
     logger,
     integrityCheckMercuryClient,
     redis,
-    sentryClient
+    sentryClient,
   );
   await integrityCheckerClient.watchLedger(checkNetwork);
 };


### PR DESCRIPTION
Closes #238 

### What

- Add functionality to pass RPC URLs for different networks as env variables.
- Use the public URLs for testnet and futurenet as default value, if not passed by user.
- Throw error if requested network is public but no URL is set by user.

### Why

- We currently hardcode the production kube cluster URL which is not a good practice.
- With our new dev and prd namespaces running their own RPC pods, we should use those URLs encoded as kube secrets for the respective freighter backend pods to connect to.