### PR TITLE
Use revRange for calculating 24h price change

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -25,6 +25,7 @@ export interface PriceConfig {
   freighterHorizonUrl: string;
   priceStalenessThreshold: number;
   usdReceiveValue: number;
+  priceOneDayThresholdMs: number;
 }
 
 export interface StellarRpcConfig {
@@ -122,6 +123,10 @@ export function buildConfig(config: Record<string, string | undefined>) {
         Number(config.USD_RECEIVE_VALUE) ||
         Number(process.env.USD_RECEIVE_VALUE!) ||
         500,
+      priceOneDayThresholdMs:
+        Number(config.PRICE_ONE_DAY_THRESHOLD_MS) ||
+        Number(process.env.PRICE_ONE_DAY_THRESHOLD_MS!) ||
+        300000,
     },
 
     blockaidConfig: {

--- a/src/service/prices/index.test.ts
+++ b/src/service/prices/index.test.ts
@@ -31,6 +31,7 @@ describe("Token Price Client", () => {
       freighterHorizonUrl: "http://test-url",
       priceStalenessThreshold: 0,
       usdReceiveValue: 500,
+      priceOneDayThresholdMs: 300000,
     };
 
     priceClient = new PriceClient(testLogger, mockPriceConfig, mockRedisClient);
@@ -68,7 +69,7 @@ describe("Token Price Client", () => {
       // Use PriceClient static properties if available, otherwise redefine
       const ONE_DAY = 24 * 60 * 60 * 1000;
       const ONE_MINUTE = 60 * 1000;
-      const twentyFourHoursAgo = mockNow - ONE_DAY;
+      const twentyFourHoursAgo = mockNow - (ONE_DAY - 5 * ONE_MINUTE);
       const muchOlderTimestamp = mockNow - 2 * ONE_DAY; // Timestamp > 24h ago
 
       // Mock ts.get to return current price data
@@ -111,7 +112,7 @@ describe("Token Price Client", () => {
       expect(mockRedisClient.ts.revRange).toHaveBeenCalledWith(
         token,
         "-",
-        twentyFourHoursAgo + ONE_MINUTE, // Match the timestamp used in getPrice
+        twentyFourHoursAgo, // Match the timestamp used in getPrice
         { COUNT: 1 },
       );
       // Check the counter increment

--- a/src/service/prices/index.test.ts
+++ b/src/service/prices/index.test.ts
@@ -105,7 +105,7 @@ describe("Token Price Client", () => {
       expect(result?.percentagePriceChange24h?.toFixed(2)).toBe("11.11");
 
       expect(mockRedisClient.ts.get).toHaveBeenCalledWith(token);
-      expect(mockRedisClient.ts.range).toHaveBeenCalledWith(token, 0, "-", {
+      expect(mockRedisClient.ts.range).toHaveBeenCalledWith(token, "-", "+", {
         COUNT: 1,
       });
       expect(mockRedisClient.ts.revRange).toHaveBeenCalledWith(

--- a/src/service/prices/index.ts
+++ b/src/service/prices/index.ts
@@ -197,7 +197,7 @@ export class PriceClient {
       let percentagePriceChange24h: BigNumber | null = null;
 
       // When calculating the 24h price change, we want to make sure the token has been tracked for at least 24 hours.
-      const firstEntry = await this.redisClient.ts.range(tsKey, 0, "-", {
+      const firstEntry = await this.redisClient.ts.range(tsKey, "-", "+", {
         COUNT: 1,
       });
       if (

--- a/src/service/prices/index.ts
+++ b/src/service/prices/index.ts
@@ -213,14 +213,14 @@ export class PriceClient {
       ) {
         // revRange traverses the time series in reverse chronological order.
         // We use the "-" symbol to indicate the earliest/oldest timestamp of the time series.
-        // We dont use the exact 1 day calculation but use an offset of 5 minutes to account for slight timing variations.
+        // We dont use the exact 1 day calculation but use an offset of few minutes to account for slight timing variations.
         const dayAgo = latestPrice.timestamp - oneDayThreshold;
         const oldPrices = await this.redisClient.ts.revRange(
           tsKey,
           "-", // Indicates the earliest/oldest timestamp of the time series
           dayAgo, // Indicates the timestamp roughly 24 hours ago from the latest price.
           {
-            COUNT: 1, // Get the single most recent entry at or before (dayAgo + 1min)
+            COUNT: 1, // Get the single most recent entry at or before dayAgo
           },
         );
 

--- a/src/service/prices/index.ts
+++ b/src/service/prices/index.ts
@@ -74,12 +74,6 @@ export class PriceClient {
   private static readonly ONE_DAY = 24 * 60 * 60 * 1000;
 
   /**
-   * Represents one minute in milliseconds (60s * 1000ms).
-   * Used as an offset window when looking up historical prices to handle slight timing variations.
-   */
-  private static readonly ONE_MINUTE = 60 * 1000;
-
-  /**
    * The time period (in milliseconds) for which to retain price data in Redis time series.
    * Currently set to 1 day in milliseconds to support 24-hour price change calculations while managing storage usage.
    */
@@ -102,6 +96,12 @@ export class PriceClient {
    * Balances update efficiency with Stellar network and Redis load.
    */
   private static readonly DEFAULT_TOKEN_UPDATE_BATCH_SIZE = 25;
+
+  /**
+   * The time delta (in milliseconds) to adjust the 1 day threshold by.
+   * Default set to 5 minutes to account for slight timing variations.
+   */
+  private static readonly DEFAULT_ONE_DAY_THRESHOLD_MS = 300000;
 
   /**
    * Maximum number of tokens to fetch and track prices for initially.
@@ -128,6 +128,8 @@ export class PriceClient {
   private readonly calculationTimeoutMs: number;
   private readonly tokenUpdateBatchSize: number;
   private readonly usdReceiveValue: BigNumber;
+  private readonly priceOneDayThresholdMs: number;
+
   /**
    * Creates a new PriceClient instance.
    *
@@ -163,6 +165,9 @@ export class PriceClient {
     this.usdReceiveValue = new BigNumber(
       priceConfig.usdReceiveValue || PriceClient.DEFAULT_USD_RECEIVE_VALUE,
     );
+    this.priceOneDayThresholdMs =
+      priceConfig.priceOneDayThresholdMs ||
+      PriceClient.DEFAULT_ONE_DAY_THRESHOLD_MS;
   }
 
   /**
@@ -195,7 +200,7 @@ export class PriceClient {
 
       const currentPrice = new BigNumber(latestPrice.value);
       let percentagePriceChange24h: BigNumber | null = null;
-      const oneDayThreshold = PriceClient.ONE_DAY - 1 * PriceClient.ONE_MINUTE;
+      const oneDayThreshold = PriceClient.ONE_DAY - this.priceOneDayThresholdMs;
 
       // When calculating the 24h price change, we want to make sure the token has been tracked for at least 24 hours.
       const firstEntry = await this.redisClient.ts.range(tsKey, "-", "+", {
@@ -204,7 +209,7 @@ export class PriceClient {
       if (
         firstEntry &&
         firstEntry.length > 0 &&
-        latestPrice.timestamp - firstEntry[0].timestamp >= oneDayThreshold
+        latestPrice.timestamp - oneDayThreshold >= firstEntry[0].timestamp
       ) {
         // revRange traverses the time series in reverse chronological order.
         // We use the "-" symbol to indicate the earliest/oldest timestamp of the time series.


### PR DESCRIPTION
## What
- Use [TS.REVRANGE](https://redis.io/docs/latest/commands/ts.revrange/) to get the approx price 24h ago.
- Add ability to specify the 24h threshold via an environment variable.

## Why
We currently store the token prices in a redis timeseries structure with a retention policy of 24h. On each request for a token we fetch the latest price and the 24h price and then calculate the 24hr % change.

The idea was to check for prices within the timestamp range = [timestamp at (24h-1min), timestamp at 24h] and get the price that falls in this interval. However, with the increase in the number of tokens in the cache, the batch updates between prices increased and the probability of finding a price within this hardcoded 1 min time interval reduced. This led to the client not able to find 24h price sometimes and showing up as "--" on the UI.

The solution was to change the 24h threshold so that we are able to find atleast 1 value around the 24h mark to calculate an approx 24h price change. Instead of hardcoding a strict 1 min window, we start looking for prices till the tail end of the timeseries structure.