### PR TITLE
Fix newline issue 2

### DIFF
--- a/src/helper/onramp.ts
+++ b/src/helper/onramp.ts
@@ -32,7 +32,15 @@ export const generateJWT = ({
     nonce: crypto.randomBytes(16).toString("hex"),
   };
 
-  return jwt.sign(payload, coinbaseConfig.coinbaseApiSecret, {
+  // When we set values in Vault, we aren't able to set this value with "" around it.
+  // Because of that, when JS interperets it, it tries to escape `/n` characters, turning them into `//n`
+  // Adding this extra slash breaks the algorithm, so we need to remove it.
+  const coinbaseApiSecret = coinbaseConfig.coinbaseApiSecret.replaceAll(
+    "\\n",
+    "\n",
+  );
+
+  return jwt.sign(payload, coinbaseApiSecret, {
     algorithm,
     header,
   });


### PR DESCRIPTION
Re-roll of #243 

Fixes a very edge-case issue with the way Vault secrets are set.

EC Private Keys contain `/n` characters because spaces and line breaks are an important part of the key. Unfortunately, if you don't set these values in .env without `""` around it, Javascript doesn't interpret it properly and tries to escape the `/n`'s.

Even more unfortunately, there doesn't see to be a way to get Vault to set these secrets with the `""` as we might do in our local `.env`. AND, the `dotenv` package doesn't provide a way to handle this either. 

Because of that, we have to handle this discrepancy in the code ourselves ☹️ 