### PR TITLE
Change scan tx to post

### DIFF
--- a/src/route/index.test.ts
+++ b/src/route/index.test.ts
@@ -546,7 +546,7 @@ describe("API routes", () => {
       await server.close();
     });
   });
-  describe.only("/scan-tx", () => {
+  describe("/scan-tx", () => {
     it("can scan a tx", async () => {
       const server = await getDevServer();
       const url = new URL(

--- a/src/route/index.ts
+++ b/src/route/index.ts
@@ -739,20 +739,16 @@ export async function initApiServer(
       });
 
       instance.route({
-        method: "GET",
+        method: "POST",
         url: "/scan-tx",
         schema: {
-          querystring: {
+          body: {
             type: "object",
-            required: ["tx_xdr", "url", "network"],
+            required: ["url", "tx_xdr", "network"],
             properties: {
-              ["tx_xdr"]: {
-                type: "string",
-              },
-              ["url"]: {
-                type: "string",
-              },
-              ["network"]: {
+              url: { type: "string" },
+              tx_xdr: { type: "string" },
+              network: {
                 type: "string",
                 validator: (qStr: string) => isNetwork(qStr),
               },
@@ -761,15 +757,15 @@ export async function initApiServer(
         },
         handler: async (
           request: FastifyRequest<{
-            Querystring: {
-              ["tx_xdr"]: string;
-              ["url"]: string;
-              ["network"]: NetworkNames;
+            Body: {
+              url: string;
+              tx_xdr: string;
+              network: NetworkNames;
             };
           }>,
           reply,
         ) => {
-          const { tx_xdr, url, network } = request.query;
+          const { tx_xdr, url, network } = request.body;
           if (blockaidConfig.useBlockaidTxScanning) {
             try {
               const { data, error } = await blockAidService.scanTx(


### PR DESCRIPTION
Closes #1963


Adds a POST method to scan-tx endpoint that will eventually replace the GET method. This will fix our issue with char limits