### PR TITLE
add query param to toggle including failed tx's

### DIFF
--- a/src/helper/horizon-rpc.ts
+++ b/src/helper/horizon-rpc.ts
@@ -68,7 +68,7 @@ export interface BalanceMap {
 }
 
 export function getBalanceIdentifier(
-  balance: StellarSdk.Horizon.HorizonApi.BalanceLine
+  balance: StellarSdk.Horizon.HorizonApi.BalanceLine,
 ): string {
   if ("asset_issuer" in balance && !balance.asset_issuer) {
     return "native";
@@ -97,7 +97,7 @@ export function getAssetType(code?: string) {
 }
 
 export const makeDisplayableBalances = (
-  accountDetails: StellarSdk.Horizon.ServerApi.AccountRecord
+  accountDetails: StellarSdk.Horizon.ServerApi.AccountRecord,
 ) => {
   const { balances, subentry_count, num_sponsored, num_sponsoring } =
     accountDetails;
@@ -186,7 +186,7 @@ export const makeDisplayableBalances = (
         },
       };
     },
-    {}
+    {},
   );
 
   return displayableBalances as BalanceMap;
@@ -194,7 +194,7 @@ export const makeDisplayableBalances = (
 
 export const fetchAccountDetails = async (
   pubKey: string,
-  server: StellarSdkNext.Horizon.Server | StellarSdk.Horizon.Server
+  server: StellarSdkNext.Horizon.Server | StellarSdk.Horizon.Server,
 ) => {
   try {
     const accountSummary = await server.accounts().accountId(pubKey).call();
@@ -224,13 +224,15 @@ export const fetchAccountDetails = async (
 
 export const fetchAccountHistory = async (
   pubKey: string,
-  server: StellarSdkNext.Horizon.Server | StellarSdk.Horizon.Server
+  server: StellarSdkNext.Horizon.Server | StellarSdk.Horizon.Server,
+  isFailedIncluded: boolean = false,
 ) => {
   try {
     const operationsData = await server
       .operations()
       .forAccount(pubKey)
       .order("desc")
+      .includeFailed(isFailedIncluded)
       .join("transactions")
       .limit(TRANSACTIONS_LIMIT)
       .call();
@@ -244,7 +246,7 @@ export const fetchAccountHistory = async (
 export const submitTransaction = async (
   signedXDR: string,
   networkUrl: string,
-  networkPassphrase: string
+  networkPassphrase: string,
 ): Promise<{
   data: StellarSdk.Horizon.HorizonApi.SubmitTransactionResponse | null;
   error: unknown;

--- a/src/helper/test-helper.ts
+++ b/src/helper/test-helper.ts
@@ -666,6 +666,7 @@ async function getDevServer(
   },
   priceConfig = mockPriceConfig,
   stellarRpcConfig = mockStellarRpcConfig,
+  useMercury = true,
 ) {
   register.clear();
 
@@ -674,7 +675,7 @@ async function getDevServer(
     blockAidService,
     mockPriceClient,
     testLogger,
-    true,
+    useMercury,
     true,
     register,
     "development",

--- a/src/route/index.test.ts
+++ b/src/route/index.test.ts
@@ -13,6 +13,7 @@ import { Networks } from "stellar-sdk-next";
 import { ERROR } from "../helper/error";
 import * as StellarHelpers from "../helper/stellar";
 import * as OnrampHelpers from "../helper/onramp";
+import * as HorizonRpcHelpers from "../helper/horizon-rpc";
 import { getStellarRpcUrls } from "../helper/soroban-rpc";
 import { StellarRpcConfig } from "../config";
 
@@ -151,6 +152,28 @@ describe("API routes", () => {
         }/api/v1/account-history/${notPubkey}`,
       );
       expect(response.status).toEqual(400);
+      await server.close();
+    });
+
+    it("includes failed tx's in stellar-sdk operations", async () => {
+      const fetchAccountHistorySpy = jest.spyOn(
+        HorizonRpcHelpers,
+        "fetchAccountHistory",
+      );
+      const server = await getDevServer(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        false,
+      );
+      await fetch(
+        `http://localhost:${
+          (server?.server?.address() as any).port
+        }/api/v1/account-history/${pubKey}?network=TESTNET&is_failed_included=true`,
+      );
+
+      expect(fetchAccountHistorySpy.mock.calls[0][2]).toEqual(true);
       await server.close();
     });
   });

--- a/src/route/index.ts
+++ b/src/route/index.ts
@@ -343,6 +343,9 @@ export async function initApiServer(
                 type: "string",
                 validator: (qStr: string) => isNetwork(qStr),
               },
+              ["is_failed_included"]: {
+                type: "string",
+              },
             },
           },
         },
@@ -351,6 +354,7 @@ export async function initApiServer(
             Params: { ["pubKey"]: string };
             Querystring: {
               ["network"]: NetworkNames;
+              ["is_failed_included"]: string;
             };
           }>,
           reply,
@@ -358,11 +362,14 @@ export async function initApiServer(
           try {
             const useMercury = await getUseMercury(mode, useMercuryConf, redis);
             const pubKey = request.params["pubKey"];
-            const { network } = request.query;
+            const { network, is_failed_included: isFailedIncluded } =
+              request.query;
+
             const { data, error } = await mercuryClient.getAccountHistory(
               pubKey,
               network,
               useMercury,
+              isFailedIncluded === "true",
             );
             if (error) {
               reply.code(400).send(JSON.stringify(error));

--- a/src/service/mercury/index.ts
+++ b/src/service/mercury/index.ts
@@ -510,7 +510,11 @@ export class MercuryClient {
     }
   };
 
-  getAccountHistoryHorizon = async (pubKey: string, network: NetworkNames) => {
+  getAccountHistoryHorizon = async (
+    pubKey: string,
+    network: NetworkNames,
+    isFailedIncluded: boolean,
+  ) => {
     try {
       const networkUrl = NETWORK_URLS[network];
       if (!networkUrl) {
@@ -523,7 +527,7 @@ export class MercuryClient {
       const server = new Horizon.Server(networkUrl, {
         allowHttp: !networkUrl.includes("https"),
       });
-      const data = await fetchAccountHistory(pubKey, server);
+      const data = await fetchAccountHistory(pubKey, server, isFailedIncluded);
       return {
         data,
         error: null,
@@ -603,6 +607,7 @@ export class MercuryClient {
     pubKey: string,
     network: NetworkNames,
     useMercury: boolean,
+    isFailedIncluded: boolean,
   ) => {
     if (hasIndexerSupport(network) && useMercury) {
       const response = await this.getAccountHistoryMercury(pubKey, network);
@@ -622,6 +627,7 @@ export class MercuryClient {
     const horizonResponse = await this.getAccountHistoryHorizon(
       pubKey,
       network,
+      isFailedIncluded,
     );
     return horizonResponse;
   };

--- a/src/service/mercury/index.ts
+++ b/src/service/mercury/index.ts
@@ -513,7 +513,7 @@ export class MercuryClient {
   getAccountHistoryHorizon = async (
     pubKey: string,
     network: NetworkNames,
-    isFailedIncluded: boolean,
+    isFailedIncluded?: boolean,
   ) => {
     try {
       const networkUrl = NETWORK_URLS[network];
@@ -607,7 +607,7 @@ export class MercuryClient {
     pubKey: string,
     network: NetworkNames,
     useMercury: boolean,
-    isFailedIncluded: boolean,
+    isFailedIncluded?: boolean,
   ) => {
     if (hasIndexerSupport(network) && useMercury) {
       const response = await this.getAccountHistoryMercury(pubKey, network);


### PR DESCRIPTION
Related to [Freighter #1844](https://github.com/stellar/freighter/issues/1844)

Parameterize account-history to only include failed tx's for Freighter users who have upgraded