### PR TITLE
hardcodes pyUSD to 1 USD in getPrice

### DIFF
--- a/src/service/prices/index.ts
+++ b/src/service/prices/index.ts
@@ -201,7 +201,7 @@ export class PriceClient {
         return null;
       }
 
-      const isPyUsd = token === PY_USD_TOKEN_KEY;
+      const isPyUsd = token === PYUSD_TOKEN_KEY;
       const currentPrice = new BigNumber(isPyUsd ? 1 : latestPrice.value);
       let percentagePriceChange24h: BigNumber | null = null;
       const oneDayThreshold = PriceClient.ONE_DAY - this.priceOneDayThresholdMs;


### PR DESCRIPTION
Hardcodes PyUSD to always return 1 for it's USD value in `getPrice`