### PR TITLE
fix: remove network_url usage from simulate-tx and submit-tx routes

### DIFF
--- a/src/route/index.test.ts
+++ b/src/route/index.test.ts
@@ -14,14 +14,6 @@ import { ERROR } from "../helper/error";
 import * as StellarHelpers from "../helper/stellar";
 import * as OnrampHelpers from "../helper/onramp";
 import * as HorizonRpcHelpers from "../helper/horizon-rpc";
-import { getStellarRpcUrls } from "../helper/soroban-rpc";
-import { StellarRpcConfig } from "../config";
-
-const mockStellarRpcConfig = {
-  freighterRpcPubnetUrl: "https://rpc-pubnet.stellar.org",
-  freighterRpcTestnetUrl: "https://rpc-testnet.stellar.org",
-  freighterRpcFuturenetUrl: "https://rpc-futurenet.stellar.org",
-} as StellarRpcConfig;
 
 jest.mock("@blockaid/client", () => {
   return class Blockaid {
@@ -996,6 +988,74 @@ describe("API routes", () => {
       await server.close();
     });
   });
+  describe("/submit-tx", () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it("can submit a transaction", async () => {
+      jest
+        .spyOn(HorizonRpcHelpers, "submitTransaction")
+        .mockResolvedValue({ data: { hash: "tx-hash" }, error: null } as any);
+
+      const server = await getDevServer();
+      const url = new URL(
+        `http://localhost:${
+          (server?.server?.address() as any).port
+        }/api/v1/submit-tx`,
+      );
+      const options = {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          signed_xdr: TEST_SOROBAN_TX,
+          network_passphrase: Networks.TESTNET,
+        }),
+      };
+      const response = await fetch(url.href, options);
+      const data = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(data).toEqual({ hash: "tx-hash" });
+      await server.close();
+    });
+
+    it("ignores network_url when passed for backwards compatibility", async () => {
+      jest
+        .spyOn(HorizonRpcHelpers, "submitTransaction")
+        .mockResolvedValue({ data: { hash: "tx-hash" }, error: null } as any);
+
+      const server = await getDevServer();
+      const url = new URL(
+        `http://localhost:${
+          (server?.server?.address() as any).port
+        }/api/v1/submit-tx`,
+      );
+      const options = {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          signed_xdr: TEST_SOROBAN_TX,
+          network_url: "https://some-user-provided-url.com",
+          network_passphrase: Networks.TESTNET,
+        }),
+      };
+      const response = await fetch(url.href, options);
+      const data = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(data).toEqual({ hash: "tx-hash" });
+      expect(HorizonRpcHelpers.submitTransaction).toHaveBeenCalledWith(
+        TEST_SOROBAN_TX,
+        Networks.TESTNET,
+      );
+      await server.close();
+    });
+  });
   describe("/simulate-tx", () => {
     const simResponse = "simulated xdr";
     const preparedTransaction = "assembled tx xdr";
@@ -1048,7 +1108,6 @@ describe("API routes", () => {
         },
         body: JSON.stringify({
           xdr: TEST_SOROBAN_TX,
-          network_url: getStellarRpcUrls(mockStellarRpcConfig).TESTNET,
           network_passphrase: Networks.TESTNET,
         }),
       };
@@ -1058,6 +1117,56 @@ describe("API routes", () => {
       expect(response.status).toEqual(200);
       expect(data.simulationResponse).toEqual(simResponse);
       expect(data.preparedTransaction).toEqual(preparedTransaction);
+      await server.close();
+    });
+
+    it("ignores network_url when passed for backwards compatibility", async () => {
+      const server = await getDevServer();
+      const url = new URL(
+        `http://localhost:${
+          (server?.server?.address() as any).port
+        }/api/v1/simulate-tx`,
+      );
+      const options = {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          xdr: TEST_SOROBAN_TX,
+          network_url: "https://some-user-provided-url.com",
+          network_passphrase: Networks.TESTNET,
+        }),
+      };
+      const response = await fetch(url.href, options);
+      const data = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(data.simulationResponse).toEqual(simResponse);
+      expect(data.preparedTransaction).toEqual(preparedTransaction);
+      await server.close();
+    });
+
+    it("returns an error for an unknown network passphrase", async () => {
+      const server = await getDevServer();
+      const url = new URL(
+        `http://localhost:${
+          (server?.server?.address() as any).port
+        }/api/v1/simulate-tx`,
+      );
+      const options = {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          xdr: TEST_SOROBAN_TX,
+          network_passphrase: "unknown-passphrase",
+        }),
+      };
+      const response = await fetch(url.href, options);
+
+      expect(response.status).toEqual(400);
       await server.close();
     });
 

--- a/src/route/index.test.ts
+++ b/src/route/index.test.ts
@@ -1021,40 +1021,6 @@ describe("API routes", () => {
       expect(data).toEqual({ hash: "tx-hash" });
       await server.close();
     });
-
-    it("ignores network_url when passed for backwards compatibility", async () => {
-      jest
-        .spyOn(HorizonRpcHelpers, "submitTransaction")
-        .mockResolvedValue({ data: { hash: "tx-hash" }, error: null } as any);
-
-      const server = await getDevServer();
-      const url = new URL(
-        `http://localhost:${
-          (server?.server?.address() as any).port
-        }/api/v1/submit-tx`,
-      );
-      const options = {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          signed_xdr: TEST_SOROBAN_TX,
-          network_url: "https://some-user-provided-url.com",
-          network_passphrase: Networks.TESTNET,
-        }),
-      };
-      const response = await fetch(url.href, options);
-      const data = await response.json();
-
-      expect(response.status).toEqual(200);
-      expect(data).toEqual({ hash: "tx-hash" });
-      expect(HorizonRpcHelpers.submitTransaction).toHaveBeenCalledWith(
-        TEST_SOROBAN_TX,
-        Networks.TESTNET,
-      );
-      await server.close();
-    });
   });
   describe("/simulate-tx", () => {
     const simResponse = "simulated xdr";
@@ -1108,33 +1074,6 @@ describe("API routes", () => {
         },
         body: JSON.stringify({
           xdr: TEST_SOROBAN_TX,
-          network_passphrase: Networks.TESTNET,
-        }),
-      };
-      const response = await fetch(url.href, options);
-      const data = await response.json();
-
-      expect(response.status).toEqual(200);
-      expect(data.simulationResponse).toEqual(simResponse);
-      expect(data.preparedTransaction).toEqual(preparedTransaction);
-      await server.close();
-    });
-
-    it("ignores network_url when passed for backwards compatibility", async () => {
-      const server = await getDevServer();
-      const url = new URL(
-        `http://localhost:${
-          (server?.server?.address() as any).port
-        }/api/v1/simulate-tx`,
-      );
-      const options = {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          xdr: TEST_SOROBAN_TX,
-          network_url: "https://some-user-provided-url.com",
           network_passphrase: Networks.TESTNET,
         }),
       };

--- a/src/route/index.ts
+++ b/src/route/index.ts
@@ -1260,6 +1260,7 @@ export async function initApiServer(
             required: ["signed_xdr", "network_passphrase"],
             properties: {
               signed_xdr: { type: "string" },
+              // network_url is accepted for backwards compatibility but ignored
               network_url: { type: "string" },
               network_passphrase: { type: "string" },
             },
@@ -1269,7 +1270,6 @@ export async function initApiServer(
           request: FastifyRequest<{
             Body: {
               signed_xdr: string;
-              network_url?: string;
               network_passphrase: string;
             };
           }>,
@@ -1299,9 +1299,10 @@ export async function initApiServer(
         schema: {
           body: {
             type: "object",
-            required: ["xdr", "network_url", "network_passphrase"],
+            required: ["xdr", "network_passphrase"],
             properties: {
               xdr: { type: "string" },
+              // network_url is accepted for backwards compatibility but ignored
               network_url: { type: "string" },
               network_passphrase: { type: "string" },
             },
@@ -1311,18 +1312,23 @@ export async function initApiServer(
           request: FastifyRequest<{
             Body: {
               xdr: string;
-              network_url: string;
               network_passphrase: string;
             };
           }>,
           reply,
         ) => {
-          const { xdr, network_url, network_passphrase } = request.body;
+          const { xdr, network_passphrase } = request.body;
 
           try {
             const Sdk = getSdk(network_passphrase as Networks);
+            const networkName = networkPassphraseToName(network_passphrase);
+            if (!networkName) {
+              throw new Error(
+                `Unknown network passphrase: ${network_passphrase}`,
+              );
+            }
             const tx = Sdk.TransactionBuilder.fromXDR(xdr, network_passphrase);
-            const server = await mercuryClient.getRpcServer(network_url);
+            const server = await getServer(networkName, stellarRpcConfig);
 
             const simulationResponse = await server.simulateTransaction(tx);
             const preparedTransaction = Sdk.rpc

--- a/src/route/index.ts
+++ b/src/route/index.ts
@@ -1260,8 +1260,6 @@ export async function initApiServer(
             required: ["signed_xdr", "network_passphrase"],
             properties: {
               signed_xdr: { type: "string" },
-              // network_url is accepted for backwards compatibility but ignored
-              network_url: { type: "string" },
               network_passphrase: { type: "string" },
             },
           },
@@ -1302,8 +1300,6 @@ export async function initApiServer(
             required: ["xdr", "network_passphrase"],
             properties: {
               xdr: { type: "string" },
-              // network_url is accepted for backwards compatibility but ignored
-              network_url: { type: "string" },
               network_passphrase: { type: "string" },
             },
           },


### PR DESCRIPTION
What
Ignores user-provided network_url in /simulate-tx and /submit-tx, resolving the RPC server from network_passphrase instead. The schema still accepts network_url for backwards compatibility but the value is no longer read. 
Adds tests for both routes covering the new behavior
