### PR TITLE
fix(src): don't persist Redis state for tokens with failed price calc

### DIFF
--- a/src/service/prices/index.test.ts
+++ b/src/service/prices/index.test.ts
@@ -2,7 +2,7 @@ import { PriceClient } from "./index";
 import { testLogger } from "../../helper/test-helper";
 import { TokenPriceData } from "./types";
 import BigNumber from "bignumber.js";
-import { PriceCalculationError } from "./errors";
+import { PathsNotFoundError, PriceCalculationError } from "./errors";
 describe("Token Price Client", () => {
   let priceClient: PriceClient;
   const mockRedisClient: any = {
@@ -16,6 +16,8 @@ describe("Token Price Client", () => {
     },
     zIncrBy: jest.fn(),
     zRange: jest.fn(),
+    zRem: jest.fn(),
+    del: jest.fn(),
     set: jest.fn(),
     multi: jest.fn(),
     get: jest.fn(),
@@ -267,9 +269,7 @@ describe("Token Price Client", () => {
       expect(result).toBeNull();
       expect(testLogger.error).toHaveBeenCalledWith(
         expect.objectContaining({
-          message: expect.stringContaining(
-            `adding new token to cache for ${token}`,
-          ),
+          message: expect.stringContaining(`calculating price for ${token}`),
         }),
       );
 
@@ -281,6 +281,31 @@ describe("Token Price Client", () => {
         expect.stringContaining(
           `Token in cache but no latest price found for ${token}`,
         ),
+      );
+    });
+
+    it("should NOT persist Redis state when price calculation fails for new token", async () => {
+      // Issue #306: addNewTokenToCache must not create a TS key or increment
+      // the token_counter sorted set when calculatePriceInUSD rejects.
+      mockRedisClient.ts.get.mockRejectedValue(new Error("Key does not exist"));
+
+      const token =
+        "FAKE:GBVK6IBOJOX44RFGUZHVH6P3RP4QYLEPZHMTCG2RMQ6GUKQTWAFXKW3J";
+      jest
+        .spyOn(priceClient as any, "calculatePriceInUSD")
+        .mockRejectedValue(new PathsNotFoundError(token));
+
+      const result = await priceClient.getPrice(token);
+
+      expect(result).toBeNull();
+      // No orphan TS key
+      expect(mockRedisClient.ts.create).not.toHaveBeenCalled();
+      expect(mockRedisClient.ts.add).not.toHaveBeenCalled();
+      // No orphan sorted-set entry
+      expect(mockRedisClient.zIncrBy).not.toHaveBeenCalledWith(
+        "token_counter",
+        expect.anything(),
+        expect.stringContaining("FAKE:"),
       );
     });
 
@@ -479,6 +504,61 @@ describe("Token Price Client", () => {
       expect(testLogger.warn).toHaveBeenCalledWith(
         "No prices calculated for batch",
       );
+    });
+
+    it("addBatchToCache should evict orphan tokens whose TS has no samples and price calc failed", async () => {
+      // Issue #306 defense-in-depth: if a token in the batch fails price
+      // calculation AND its TS has zero samples, treat it as an orphan and
+      // remove it from token_counter + delete the empty TS key.
+      jest
+        .spyOn(priceClient as any, "calculatePriceInUSD")
+        .mockImplementation((token: any) => {
+          if (token === "GOOD:TOKEN") {
+            return Promise.resolve({
+              timestamp: 111,
+              price: new BigNumber(100),
+            });
+          }
+          return Promise.reject(new PathsNotFoundError(token as string));
+        });
+
+      // Orphan TS has no samples — ts.get returns null
+      mockRedisClient.ts.get.mockResolvedValue(null);
+
+      await priceClient["addBatchToCache"](["GOOD:TOKEN", "ORPHAN:TOKEN"]);
+
+      expect(mockRedisClient.zRem).toHaveBeenCalledWith(
+        "token_counter",
+        "ORPHAN:TOKEN",
+      );
+      expect(mockRedisClient.del).toHaveBeenCalledWith("ORPHAN:TOKEN");
+      // Good token's price still added
+      expect(mockRedisClient.ts.mAdd).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            key: "GOOD:TOKEN",
+            timestamp: 111,
+            value: 100,
+          }),
+        ]),
+      );
+    });
+
+    it("addBatchToCache should NOT evict tokens with existing samples on transient calc failure", async () => {
+      jest
+        .spyOn(priceClient as any, "calculatePriceInUSD")
+        .mockRejectedValue(new Error("transient horizon error"));
+
+      // TS has at least one sample — token is healthy, just transient failure
+      mockRedisClient.ts.get.mockResolvedValue({
+        timestamp: 1234,
+        value: 99,
+      });
+
+      await priceClient["addBatchToCache"](["HEALTHY:TOKEN"]);
+
+      expect(mockRedisClient.zRem).not.toHaveBeenCalled();
+      expect(mockRedisClient.del).not.toHaveBeenCalled();
     });
 
     it("getTimeSeriesKey should handle native asset correctly", async () => {

--- a/src/service/prices/index.test.ts
+++ b/src/service/prices/index.test.ts
@@ -21,7 +21,6 @@ describe("Token Price Client", () => {
     set: jest.fn(),
     multi: jest.fn(),
     get: jest.fn(),
-    exists: jest.fn(),
   };
 
   beforeEach(() => {
@@ -582,32 +581,12 @@ describe("Token Price Client", () => {
       expect(mockRedisClient.del).not.toHaveBeenCalled();
     });
 
-    it("addBatchToCache should NOT evict when ts.get errors but key still exists", async () => {
-      // Defense against transient Redis errors: a failing ts.get must not by
-      // itself trigger eviction — the key may still exist with valid samples.
-      jest
-        .spyOn(priceClient as any, "calculatePriceInUSD")
-        .mockRejectedValue(new PathsNotFoundError("HEALTHY:TOKEN"));
-
-      mockRedisClient.ts.get.mockRejectedValue(
-        new Error("transient redis error"),
-      );
-      mockRedisClient.exists.mockResolvedValue(1);
-
-      await priceClient["addBatchToCache"](["HEALTHY:TOKEN"]);
-
-      expect(mockRedisClient.exists).toHaveBeenCalledWith("HEALTHY:TOKEN");
-      expect(mockRedisClient.zRem).not.toHaveBeenCalled();
-      expect(mockRedisClient.del).not.toHaveBeenCalled();
-    });
-
-    it("addBatchToCache should evict when ts.get errors and exists confirms key is gone", async () => {
+    it("addBatchToCache should evict when ts.get throws for missing key", async () => {
       jest
         .spyOn(priceClient as any, "calculatePriceInUSD")
         .mockRejectedValue(new PathsNotFoundError("ORPHAN:TOKEN"));
 
-      mockRedisClient.ts.get.mockRejectedValue(new Error("key may not exist"));
-      mockRedisClient.exists.mockResolvedValue(0);
+      mockRedisClient.ts.get.mockRejectedValue(new Error("key does not exist"));
 
       await priceClient["addBatchToCache"](["ORPHAN:TOKEN"]);
 

--- a/src/service/prices/index.test.ts
+++ b/src/service/prices/index.test.ts
@@ -21,6 +21,7 @@ describe("Token Price Client", () => {
     set: jest.fn(),
     multi: jest.fn(),
     get: jest.fn(),
+    exists: jest.fn(),
   };
 
   beforeEach(() => {
@@ -302,11 +303,31 @@ describe("Token Price Client", () => {
       expect(mockRedisClient.ts.create).not.toHaveBeenCalled();
       expect(mockRedisClient.ts.add).not.toHaveBeenCalled();
       // No orphan sorted-set entry
-      expect(mockRedisClient.zIncrBy).not.toHaveBeenCalledWith(
-        "token_counter",
-        expect.anything(),
-        expect.stringContaining("FAKE:"),
+      expect(mockRedisClient.zIncrBy).not.toHaveBeenCalled();
+    });
+
+    it("should normalize 'native' to XLM when populating a cache miss", async () => {
+      // calculatePriceInUSD only special-cases "XLM"; passing the raw "native"
+      // would throw InvalidTokenFormatError. addNewTokenToCache must normalize
+      // first so a cache miss for "native" populates correctly.
+      mockRedisClient.ts.get.mockRejectedValue(new Error("Key does not exist"));
+
+      const calcSpy = jest
+        .spyOn(priceClient as any, "calculatePriceInUSD")
+        .mockResolvedValue({
+          timestamp: 222,
+          price: new BigNumber(0.12),
+        });
+
+      const result = await priceClient.getPrice("native");
+
+      expect(calcSpy).toHaveBeenCalledWith("XLM");
+      expect(mockRedisClient.ts.create).toHaveBeenCalledWith(
+        "XLM",
+        expect.any(Object),
       );
+      expect(mockRedisClient.ts.add).toHaveBeenCalledWith("XLM", 222, 0.12);
+      expect(result?.currentPrice.toNumber()).toBe(0.12);
     });
 
     it("handles errors", async () => {
@@ -559,6 +580,42 @@ describe("Token Price Client", () => {
 
       expect(mockRedisClient.zRem).not.toHaveBeenCalled();
       expect(mockRedisClient.del).not.toHaveBeenCalled();
+    });
+
+    it("addBatchToCache should NOT evict when ts.get errors but key still exists", async () => {
+      // Defense against transient Redis errors: a failing ts.get must not by
+      // itself trigger eviction — the key may still exist with valid samples.
+      jest
+        .spyOn(priceClient as any, "calculatePriceInUSD")
+        .mockRejectedValue(new PathsNotFoundError("HEALTHY:TOKEN"));
+
+      mockRedisClient.ts.get.mockRejectedValue(
+        new Error("transient redis error"),
+      );
+      mockRedisClient.exists.mockResolvedValue(1);
+
+      await priceClient["addBatchToCache"](["HEALTHY:TOKEN"]);
+
+      expect(mockRedisClient.exists).toHaveBeenCalledWith("HEALTHY:TOKEN");
+      expect(mockRedisClient.zRem).not.toHaveBeenCalled();
+      expect(mockRedisClient.del).not.toHaveBeenCalled();
+    });
+
+    it("addBatchToCache should evict when ts.get errors and exists confirms key is gone", async () => {
+      jest
+        .spyOn(priceClient as any, "calculatePriceInUSD")
+        .mockRejectedValue(new PathsNotFoundError("ORPHAN:TOKEN"));
+
+      mockRedisClient.ts.get.mockRejectedValue(new Error("key may not exist"));
+      mockRedisClient.exists.mockResolvedValue(0);
+
+      await priceClient["addBatchToCache"](["ORPHAN:TOKEN"]);
+
+      expect(mockRedisClient.zRem).toHaveBeenCalledWith(
+        "token_counter",
+        "ORPHAN:TOKEN",
+      );
+      expect(mockRedisClient.del).toHaveBeenCalledWith("ORPHAN:TOKEN");
     });
 
     it("getTimeSeriesKey should handle native asset correctly", async () => {

--- a/src/service/prices/index.test.ts
+++ b/src/service/prices/index.test.ts
@@ -305,6 +305,66 @@ describe("Token Price Client", () => {
       expect(mockRedisClient.zIncrBy).not.toHaveBeenCalled();
     });
 
+    it("should clean up partial state when ts.add fails after createTimeSeries", async () => {
+      // If ts.add throws after createTimeSeries has already run ts.create +
+      // zIncrBy, addNewTokenToCache must compensate so we don't leave an
+      // orphan TS key + token_counter entry for the next evictOrphans tick.
+      mockRedisClient.ts.get.mockRejectedValue(new Error("Key does not exist"));
+
+      const token =
+        "FAKE:GBVK6IBOJOX44RFGUZHVH6P3RP4QYLEPZHMTCG2RMQ6GUKQTWAFXKW3J";
+      jest.spyOn(priceClient as any, "calculatePriceInUSD").mockResolvedValue({
+        timestamp: 222,
+        price: new BigNumber(0.12),
+      });
+
+      mockRedisClient.ts.add.mockRejectedValueOnce(new Error("redis blip"));
+
+      const result = await priceClient.getPrice(token);
+
+      expect(result).toBeNull();
+      // createTimeSeries did run, so both writes happened…
+      expect(mockRedisClient.ts.create).toHaveBeenCalledWith(
+        token,
+        expect.any(Object),
+      );
+      expect(mockRedisClient.zIncrBy).toHaveBeenCalledWith(
+        "token_counter",
+        1,
+        token,
+      );
+      // …and the catch arm must have undone them.
+      expect(mockRedisClient.zRem).toHaveBeenCalledWith("token_counter", token);
+      expect(mockRedisClient.del).toHaveBeenCalledWith(token);
+    });
+
+    it("should not throw if compensating cleanup itself fails", async () => {
+      // Cleanup is best-effort: a failure in zRem/del must not mask the
+      // original ts.add error or surface as an unhandled rejection.
+      mockRedisClient.ts.get.mockRejectedValue(new Error("Key does not exist"));
+
+      const token =
+        "FAKE:GBVK6IBOJOX44RFGUZHVH6P3RP4QYLEPZHMTCG2RMQ6GUKQTWAFXKW3J";
+      jest.spyOn(priceClient as any, "calculatePriceInUSD").mockResolvedValue({
+        timestamp: 222,
+        price: new BigNumber(0.12),
+      });
+
+      mockRedisClient.ts.add.mockRejectedValueOnce(new Error("redis blip"));
+      mockRedisClient.zRem.mockRejectedValueOnce(new Error("still flaky"));
+
+      const result = await priceClient.getPrice(token);
+
+      expect(result).toBeNull();
+      expect(testLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            `cleaning up partial cache state for ${token}`,
+          ),
+        }),
+      );
+    });
+
     it("should normalize 'native' to XLM when populating a cache miss", async () => {
       // calculatePriceInUSD only special-cases "XLM"; passing the raw "native"
       // would throw InvalidTokenFormatError. addNewTokenToCache must normalize

--- a/src/service/prices/index.ts
+++ b/src/service/prices/index.ts
@@ -445,16 +445,37 @@ export class PriceClient {
     }
     for (const token of tokens) {
       const tsKey = this.getTimeSeriesKey(token);
-      let hasSamples = false;
+      let shouldEvict = false;
       try {
         const latest = await this.redisClient.ts.get(tsKey);
-        hasSamples = !!latest;
+        shouldEvict = !latest;
       } catch (e) {
-        // Key does not exist — still want to drop the sorted-set entry.
-        hasSamples = false;
+        // ts.get failed — only treat as orphan if the key truly does not
+        // exist. A transient Redis error must not evict a healthy token.
+        try {
+          const exists = await this.redisClient.exists(tsKey);
+          if (exists) {
+            this.logger.error(
+              ensureError(
+                e,
+                `checking time-series samples for ${token}; key exists so skipping orphan eviction`,
+              ),
+            );
+            continue;
+          }
+          shouldEvict = true;
+        } catch (existsError) {
+          this.logger.error(
+            ensureError(
+              existsError,
+              `verifying time-series existence for ${token}; skipping orphan eviction`,
+            ),
+          );
+          continue;
+        }
       }
 
-      if (hasSamples) {
+      if (!shouldEvict) {
         continue;
       }
 
@@ -629,17 +650,20 @@ export class PriceClient {
       throw new Error("Redis client not initialized");
     }
 
+    // Normalize first so "native" is handled the same as "XLM" downstream —
+    // calculatePriceInUSD only special-cases "XLM", and the TS key uses "XLM".
+    const tsKey = this.getTimeSeriesKey(token);
+
     // Calculate the price first so a failed calculation never persists an
     // orphan TS key or token_counter entry that the worker would retry forever.
     let result: PriceCalculationResult;
     try {
-      result = await this.calculatePriceInUSD(token);
+      result = await this.calculatePriceInUSD(tsKey);
     } catch (e) {
       this.logger.error(ensureError(e, `calculating price for ${token}`));
       return null;
     }
 
-    const tsKey = this.getTimeSeriesKey(token);
     try {
       await this.createTimeSeries(tsKey);
       await this.redisClient.ts.add(

--- a/src/service/prices/index.ts
+++ b/src/service/prices/index.ts
@@ -413,6 +413,17 @@ export class PriceClient {
    */
   private async addBatchToCache(tokenBatch: TokenKey[]): Promise<void> {
     const prices = await this.calculateBatchPrices(tokenBatch);
+
+    // Defense-in-depth: if a token in the batch failed price calculation and
+    // its TS key has no samples, treat it as an orphan (e.g. created before
+    // the addNewTokenToCache reorder fix) and evict it so the worker stops
+    // retrying it indefinitely.
+    const succeeded = new Set(prices.map((p) => p.token));
+    const failed = tokenBatch.filter((token) => !succeeded.has(token));
+    if (failed.length > 0) {
+      await this.evictOrphans(failed);
+    }
+
     if (prices.length === 0) {
       this.logger.warn("No prices calculated for batch");
       return;
@@ -426,6 +437,38 @@ export class PriceClient {
       }),
     );
     await this.redisClient!.ts.mAdd(mAddEntries);
+  }
+
+  private async evictOrphans(tokens: TokenKey[]): Promise<void> {
+    if (!this.redisClient) {
+      return;
+    }
+    for (const token of tokens) {
+      const tsKey = this.getTimeSeriesKey(token);
+      let hasSamples = false;
+      try {
+        const latest = await this.redisClient.ts.get(tsKey);
+        hasSamples = !!latest;
+      } catch (e) {
+        // Key does not exist — still want to drop the sorted-set entry.
+        hasSamples = false;
+      }
+
+      if (hasSamples) {
+        continue;
+      }
+
+      try {
+        await this.redisClient.zRem(
+          PriceClient.TOKEN_COUNTER_SORTED_SET_KEY,
+          tsKey,
+        );
+        await this.redisClient.del(tsKey);
+        this.logger.warn(`Evicted orphan token ${token} from price cache`);
+      } catch (e) {
+        this.logger.error(ensureError(e, `evicting orphan ${token}`));
+      }
+    }
   }
 
   /**
@@ -582,36 +625,39 @@ export class PriceClient {
   private addNewTokenToCache = async (
     token: TokenKey,
   ): Promise<TokenPriceData | null> => {
+    if (!this.redisClient) {
+      throw new Error("Redis client not initialized");
+    }
+
+    // Calculate the price first so a failed calculation never persists an
+    // orphan TS key or token_counter entry that the worker would retry forever.
+    let result: PriceCalculationResult;
     try {
-      if (!this.redisClient) {
-        throw new Error("Redis client not initialized");
-      }
-
-      let tsKey: string;
-      try {
-        tsKey = this.getTimeSeriesKey(token);
-        await this.createTimeSeries(tsKey);
-      } catch (e) {
-        throw new Error(`creating time series for ${token}`);
-      }
-
-      const { timestamp, price } = await this.calculatePriceInUSD(token);
-
-      try {
-        await this.redisClient.ts.add(tsKey, timestamp, price.toNumber());
-      } catch (e) {
-        throw new Error(`adding price to time series for ${token}`);
-      }
-
-      return {
-        currentPrice: price,
-        percentagePriceChange24h: null,
-      } as TokenPriceData;
+      result = await this.calculatePriceInUSD(token);
     } catch (e) {
-      const error = ensureError(e, `adding new token to cache for ${token}`);
-      this.logger.error(error);
+      this.logger.error(ensureError(e, `calculating price for ${token}`));
       return null;
     }
+
+    const tsKey = this.getTimeSeriesKey(token);
+    try {
+      await this.createTimeSeries(tsKey);
+      await this.redisClient.ts.add(
+        tsKey,
+        result.timestamp,
+        result.price.toNumber(),
+      );
+    } catch (e) {
+      this.logger.error(
+        ensureError(e, `adding new token to cache for ${token}`),
+      );
+      return null;
+    }
+
+    return {
+      currentPrice: result.price,
+      percentagePriceChange24h: null,
+    };
   };
 
   /**

--- a/src/service/prices/index.ts
+++ b/src/service/prices/index.ts
@@ -445,37 +445,18 @@ export class PriceClient {
     }
     for (const token of tokens) {
       const tsKey = this.getTimeSeriesKey(token);
-      let shouldEvict = false;
+      let hasSamples = false;
       try {
         const latest = await this.redisClient.ts.get(tsKey);
-        shouldEvict = !latest;
+        hasSamples = !!latest;
       } catch (e) {
-        // ts.get failed — only treat as orphan if the key truly does not
-        // exist. A transient Redis error must not evict a healthy token.
-        try {
-          const exists = await this.redisClient.exists(tsKey);
-          if (exists) {
-            this.logger.error(
-              ensureError(
-                e,
-                `checking time-series samples for ${token}; key exists so skipping orphan eviction`,
-              ),
-            );
-            continue;
-          }
-          shouldEvict = true;
-        } catch (existsError) {
-          this.logger.error(
-            ensureError(
-              existsError,
-              `verifying time-series existence for ${token}; skipping orphan eviction`,
-            ),
-          );
-          continue;
-        }
+        // ts.get on a missing key throws — treat as no samples and evict.
+        // Mirrors the pattern used by getPrice (any error → cache miss path).
+        // Transient-error defense belongs at the client layer, not here.
+        hasSamples = false;
       }
 
-      if (!shouldEvict) {
+      if (hasSamples) {
         continue;
       }
 

--- a/src/service/prices/index.ts
+++ b/src/service/prices/index.ts
@@ -656,6 +656,23 @@ export class PriceClient {
       this.logger.error(
         ensureError(e, `adding new token to cache for ${token}`),
       );
+      // Compensate for partial state: createTimeSeries writes both the TS
+      // key and the token_counter entry, so a failed ts.add would otherwise
+      // leave an orphan until the next evictOrphans pass on the worker tick.
+      try {
+        await this.redisClient.zRem(
+          PriceClient.TOKEN_COUNTER_SORTED_SET_KEY,
+          tsKey,
+        );
+        await this.redisClient.del(tsKey);
+      } catch (cleanupErr) {
+        this.logger.warn(
+          ensureError(
+            cleanupErr,
+            `cleaning up partial cache state for ${token}`,
+          ),
+        );
+      }
       return null;
     }
 


### PR DESCRIPTION
Closes #306 

`addNewTokenToCache` used to create the TS key and zIncrBy token_counterbefore calculating the price. When calculatePriceInUSD threw (e.g. PathsNotFoundError for tokens with no Stellar path to USDC), the outer catch returned null but left an orphan TS key and sorted-set entry, which the worker then retried forever on every tick.

- Reorder `addNewTokenToCache` so `calculatePriceInUSD` runs first; only create the TS key and increment `token_counter` on success.
- Defense-in-depth: in `addBatchToCache`, evict tokens whose calc failed AND whose TS has zero samples (zRem + del). Healthy tokens with existing samples are left alone for retry.