### PR TITLE
chore: bump global API rate limit from 100 to 300 req/min

### DIFF
--- a/src/route/index.ts
+++ b/src/route/index.ts
@@ -122,7 +122,7 @@ export async function initApiServer(
     return ajv.compile(schema);
   });
   server.register(rateLimiter, {
-    max: 100,
+    max: 300,
     timeWindow: "1 minute",
     redis,
   });


### PR DESCRIPTION
## Summary

Bumps the global per-IP rate limit on the main API server from 100 req/min to 300 req/min (`src/route/index.ts:125`). The `/onramp/token` route-level limit (20/min) is unchanged.

## Rationale

- Sentry issue [`FREIGHTER-DMQ`](https://stellarorg.sentry.io/issues/7440624059/) ("No error message" on `/index.html`) has been firing continuously since 2026-04-25 — its alert rule (≥10 errors/hr) trips multiple times per day, each with 100–141 accumulated events. These are overwhelmingly 429s from the extension hitting the global limit.
- The limiter keys on client IP, so users behind shared egress (corporate networks, mobile carrier CGNAT, VPNs) share one bucket. A wallet-open burst (~5–15 reqs: balances, prices, history, token metadata) plus poll loops means ~15–20 concurrent users behind one IP can legitimately hit 100/min.
- 300/min gives roughly 3× headroom while still being meaningfully restrictive — well below comparable public crypto data APIs (e.g. Coinbase public ≈ 600/min) and still effective against scripted abuse.
- If `FREIGHTER-DMQ` doesn't quiet within a day or two after deploy, the right next step is per-user/API-key bucketing rather than continuing to widen the IP bucket.

## Test plan

- [ ] CI passes
- [ ] After deploy, monitor `FREIGHTER-DMQ` event rate in Sentry — expect a sharp drop
- [ ] Spot-check Grafana for any unusual upstream load (Horizon, RPC, price provider) now that more requests get through

🤖 Generated with [Claude Code](https://claude.com/claude-code)