### PR TITLE
fix(metrics): bound Prometheus label cardinality on http_request_duration_s

### DIFF
--- a/src/helper/metrics.ts
+++ b/src/helper/metrics.ts
@@ -152,13 +152,21 @@ export const httpLabelUrl = (url: string) => {
   };
 };
 
+// HTTP methods the API actually serves. Bucketing anything else as "other"
+// keeps the `method` label bounded as defense-in-depth: the HTTP parser already
+// rejects unrecognized methods, but this avoids relying on that behavior.
+const METHOD_WHITELIST = ["GET", "POST", "OPTIONS", "HEAD"];
+
+export const httpLabelMethod = (method: string) =>
+  METHOD_WHITELIST.includes(method) ? method : "other";
+
 export const getHttpRequestDurationLabels = (
   request: FastifyRequest,
   reply: FastifyReply,
 ) => {
   const { route, network } = httpLabelUrl(request.url);
   return {
-    method: request.method,
+    method: httpLabelMethod(request.method),
     route,
     network,
     status: reply.statusCode,

--- a/src/helper/metrics.ts
+++ b/src/helper/metrics.ts
@@ -1,6 +1,8 @@
 import { FastifyReply, FastifyRequest } from "fastify";
 import Prometheus from "prom-client";
 
+import { isNetwork } from "./validate";
+
 export enum WorkerMessage {
   INTEGRITY_CHECK_PASS = "integrityCheckPass",
   INTEGRITY_CHECK_FAIL = "integrityCheckFail",
@@ -81,7 +83,12 @@ const ROUTE_WHITELIST = [
 export const httpLabelUrl = (url: string) => {
   const [route, search] = url.split("?");
   const params = new URLSearchParams(search);
-  const network = params.get("network") || "unknown";
+  const rawNetwork = params.get("network");
+  // Canonicalize to the finite set of known Stellar networks. The metrics hook
+  // runs on every response (including validation failures) and reads the raw
+  // query string, so without this bound any unauthenticated caller could inject
+  // unbounded `network` label values and blow up Prometheus cardinality.
+  const network = rawNetwork && isNetwork(rawNetwork) ? rawNetwork : "unknown";
 
   // Extract the path without the /api/v1 prefix
   const pathMatch = route.match(/^\/api\/v\d+(.*)$/);

--- a/src/helper/test/metrics.test.ts
+++ b/src/helper/test/metrics.test.ts
@@ -1,4 +1,4 @@
-import { httpLabelUrl } from "../metrics";
+import { httpLabelUrl, httpLabelMethod } from "../metrics";
 
 describe("httpLabelUrl", () => {
   it("should return an account-history label for relevant routes", () => {
@@ -62,14 +62,38 @@ describe("httpLabelUrl", () => {
   });
 
   it("should preserve all known Stellar networks", () => {
-    for (const network of ["PUBLIC", "TESTNET", "FUTURENET"]) {
+    for (const network of [
+      "PUBLIC",
+      "TESTNET",
+      "FUTURENET",
+      "SANDBOX",
+      "STANDALONE",
+    ]) {
       const labels = httpLabelUrl(`/api/v1/rpc-health?network=${network}`);
       expect(labels.network).toEqual(network);
     }
   });
 
+  it("should bucket a case-variant network value to 'unknown'", () => {
+    const labels = httpLabelUrl("/api/v1/rpc-health?network=public");
+    expect(labels.network).toEqual("unknown");
+  });
+
   it("should bucket an empty network value to 'unknown'", () => {
     const labels = httpLabelUrl("/api/v1/rpc-health?network=");
     expect(labels.network).toEqual("unknown");
+  });
+});
+
+describe("httpLabelMethod", () => {
+  it("should preserve the methods the API serves", () => {
+    for (const method of ["GET", "POST", "OPTIONS", "HEAD"]) {
+      expect(httpLabelMethod(method)).toEqual(method);
+    }
+  });
+
+  it("should bucket unrecognized methods to 'other' to bound cardinality", () => {
+    expect(httpLabelMethod("PROPFIND")).toEqual("other");
+    expect(httpLabelMethod("CUSTOMMETHODabc123")).toEqual("other");
   });
 });

--- a/src/helper/test/metrics.test.ts
+++ b/src/helper/test/metrics.test.ts
@@ -54,4 +54,22 @@ describe("httpLabelUrl", () => {
     expect(labels.network).toEqual("unknown");
     expect(labels.route).toEqual("/rpc-health");
   });
+
+  it("should bucket unknown network values to 'unknown' to bound cardinality", () => {
+    const labels = httpLabelUrl("/api/v1/rpc-health?network=REL_ATTACK_12345");
+    expect(labels.network).toEqual("unknown");
+    expect(labels.route).toEqual("/rpc-health");
+  });
+
+  it("should preserve all known Stellar networks", () => {
+    for (const network of ["PUBLIC", "TESTNET", "FUTURENET"]) {
+      const labels = httpLabelUrl(`/api/v1/rpc-health?network=${network}`);
+      expect(labels.network).toEqual(network);
+    }
+  });
+
+  it("should bucket an empty network value to 'unknown'", () => {
+    const labels = httpLabelUrl("/api/v1/rpc-health?network=");
+    expect(labels.network).toEqual("unknown");
+  });
 });


### PR DESCRIPTION
## What & why

The `http_request_duration_s` histogram populated its `network` label from the **raw** `network` query-string value parsed out of `request.url`. The `onResponse` metrics hook runs on *every* response — including requests that fail route validation (400) or get rate-limited (429) — so an unauthenticated caller could inject arbitrary, unbounded label values:

```
GET /api/v1/ping?network=anything-i-want
GET /api/v1/rpc-health?network=REL_ATTACK_0
GET /api/v1/rpc-health?network=REL_ATTACK_1
...
```

Each unique value becomes a permanent Prometheus time series for the life of the process. Enough of them grows the in-process registry without limit and can push the pod toward memory exhaustion. Note the route-level `isNetwork()` validation does **not** protect against this — the metrics hook reads the raw URL independently of validation, and the label is recorded even when the request is rejected.

This was reported via HackerOne. The headline "OOM-kills production" claim in that report was demonstrated against an artificially tiny 192 MiB container and is overstated for our real deployments, but the underlying unbounded-cardinality bug is genuine and worth closing.

## The fix

`httpLabelUrl()` now canonicalizes `network` to the finite set of known Stellar networks via the existing `isNetwork()` helper, bucketing anything else (including empty/garbage values) as `"unknown"`. This reuses the same validation the routes already trust, so legitimate traffic is unaffected.

While here — and prompted by code review — the same histogram's `method` label was also recorded raw. The HTTP parser already rejects unrecognized methods, but we no longer rely on that: `method` is now bucketed to the handful the API actually serves (`GET`/`POST`/`OPTIONS`/`HEAD`), else `"other"`. The remaining labels (`route`, `status`) were already bounded.

## Testing

- `yarn test src/helper/test/metrics.test.ts` — added cases for arbitrary/empty/case-variant network values bucketing to `unknown`, all five known networks preserved, and method bucketing.
- Full suite: 146 passed, 3 skipped, 0 failed.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)