### PR TITLE
fix: use configured Horizon for PUBLIC classic balance reads

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -151,6 +151,7 @@ async function main() {
     },
     conf.stellarRpcConfig,
     redis,
+    conf.priceConfig.freighterHorizonUrl,
   );
 
   const priceClient = new PriceClient(

--- a/src/service/mercury/index.ts
+++ b/src/service/mercury/index.ts
@@ -107,6 +107,7 @@ export class MercuryClient {
   };
   rpcConfig: StellarRpcConfig;
   redisClient?: Redis;
+  freighterHorizonUrl?: string;
   logger: Logger;
   mercuryErrorCounter: Prometheus.Counter<"endpoint">;
   rpcErrorCounter: Prometheus.Counter<"rpc">;
@@ -123,11 +124,13 @@ export class MercuryClient {
     },
     rpcConfig: StellarRpcConfig,
     redisClient?: Redis,
+    freighterHorizonUrl?: string,
   ) {
     this.mercurySession = mercurySession;
     this.logger = logger;
     this.redisClient = redisClient;
     this.rpcConfig = rpcConfig;
+    this.freighterHorizonUrl = freighterHorizonUrl;
     this.mercuryErrorCounter = metrics.mercuryErrorCounter;
     this.rpcErrorCounter = metrics.rpcErrorCounter;
     this.criticalError = metrics.criticalError;
@@ -692,7 +695,12 @@ export class MercuryClient {
   };
 
   getAccountBalancesHorizon = async (pubKey: string, network: NetworkNames) => {
-    const networkUrl = NETWORK_URLS[network];
+    // Classic balances use the configured Horizon for PUBLIC when set (a pubnet
+    // instance); other networks fall back to the network's default Horizon.
+    const networkUrl =
+      network === "PUBLIC" && this.freighterHorizonUrl
+        ? this.freighterHorizonUrl
+        : NETWORK_URLS[network];
     if (!networkUrl) {
       throw new Error(ERROR.UNSUPPORTED_NETWORK);
     }


### PR DESCRIPTION
## What
`getAccountBalancesHorizon` hardcoded `NETWORK_URLS[network]`, so PUBLIC classic-balance reads always hit public `horizon.stellar.org` and ignored `FREIGHTER_HORIZON_URL`. This threads `freighterHorizonUrl` into `MercuryClient` and prefers it for PUBLIC, falling back to the network default when unset. Only the balances path changes — the account-history endpoint is unchanged.

## Why
When `FREIGHTER_HORIZON_URL` points at a dedicated/private Horizon, classic-balance reads still went to public `horizon.stellar.org`. Under sustained load that Horizon rate-limits (HTTP 429), and the SDK throws a `SyntaxError` parsing the non-JSON "Too Many Requests" body, which is unhandled and surfaces as a 500. Routing PUBLIC reads to the configured (unthrottled) Horizon removes that failure mode.

## Notes
- Gated on `network === "PUBLIC"` since the configured instance is a pubnet Horizon; testnet/futurenet keep the network default.
- `FREIGHTER_HORIZON_URL` previously only fed the health-check ping, not balances.

## Testing
- `tsc --noEmit` clean
- mercury test suite: 13 passed / 0 failed
- prettier clean