### PR TITLE
fix(account-balances): configurable Horizon for PUBLIC + env to disable Blockaid asset scan

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ const ENV_KEYS = [
   "BLOCKAID_KEY",
   "FREIGHTER_HORIZON_URL",
   "DISABLE_TOKEN_PRICES",
+  "DISABLE_BLOCKAID_ASSET_SCANNING",
   "FREIGHTER_RPC_PUBNET_URL",
 ];
 
@@ -137,7 +138,10 @@ export function buildConfig(config: Record<string, string | undefined>) {
     blockaidConfig: {
       useBlockaidDappScanning: true,
       useBlockaidTxScanning: true,
-      useBlockaidAssetScanning: true,
+      useBlockaidAssetScanning: !(
+        config.DISABLE_BLOCKAID_ASSET_SCANNING === "true" ||
+        process.env.DISABLE_BLOCKAID_ASSET_SCANNING === "true"
+      ),
       useBlockaidAssetWarningReporting: true,
       useBlockaidTransactionWarningReporting: true,
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,6 +151,7 @@ async function main() {
     },
     conf.stellarRpcConfig,
     redis,
+    conf.priceConfig.freighterHorizonUrl,
   );
 
   const priceClient = new PriceClient(

--- a/src/service/mercury/index.ts
+++ b/src/service/mercury/index.ts
@@ -107,6 +107,7 @@ export class MercuryClient {
   };
   rpcConfig: StellarRpcConfig;
   redisClient?: Redis;
+  freighterHorizonUrl?: string;
   logger: Logger;
   mercuryErrorCounter: Prometheus.Counter<"endpoint">;
   rpcErrorCounter: Prometheus.Counter<"rpc">;
@@ -123,11 +124,13 @@ export class MercuryClient {
     },
     rpcConfig: StellarRpcConfig,
     redisClient?: Redis,
+    freighterHorizonUrl?: string,
   ) {
     this.mercurySession = mercurySession;
     this.logger = logger;
     this.redisClient = redisClient;
     this.rpcConfig = rpcConfig;
+    this.freighterHorizonUrl = freighterHorizonUrl;
     this.mercuryErrorCounter = metrics.mercuryErrorCounter;
     this.rpcErrorCounter = metrics.rpcErrorCounter;
     this.criticalError = metrics.criticalError;
@@ -707,7 +710,12 @@ export class MercuryClient {
   };
 
   getAccountBalancesHorizon = async (pubKey: string, network: NetworkNames) => {
-    const networkUrl = NETWORK_URLS[network];
+    // Classic balances use the configured Horizon for PUBLIC when set (a pubnet
+    // instance); other networks fall back to the network's default Horizon.
+    const networkUrl =
+      network === "PUBLIC" && this.freighterHorizonUrl
+        ? this.freighterHorizonUrl
+        : NETWORK_URLS[network];
     if (!networkUrl) {
       throw new Error(ERROR.UNSUPPORTED_NETWORK);
     }


### PR DESCRIPTION
## What
Two related changes to the `/account-balances` path, both safe-by-default (no behavior change unless the new env vars are set):

1. **Configurable Horizon for PUBLIC classic balances.** `getAccountBalancesHorizon` hardcoded `NETWORK_URLS[network]`, so PUBLIC classic-balance reads always hit public `horizon.stellar.org` and ignored `FREIGHTER_HORIZON_URL`. Thread `freighterHorizonUrl` into `MercuryClient` and prefer it for PUBLIC, falling back to the network default when unset. The account-history endpoint is unchanged.

2. **Env to disable Blockaid asset scanning.** `useBlockaidAssetScanning` was hardcoded `true`. Gate it behind `DISABLE_BLOCKAID_ASSET_SCANNING` (defaults off → scanning stays on). When set, `/account-balances` skips the Blockaid `scanAssetBulk` enrichment.

## Why
- **Horizon:** when `FREIGHTER_HORIZON_URL` points at a dedicated/private Horizon, classic-balance reads still went to public `horizon.stellar.org`. Under sustained load that Horizon rate-limits (HTTP 429), and the SDK throws a `SyntaxError` parsing the non-JSON "Too Many Requests" body — unhandled, so it surfaces as a 500. Routing PUBLIC reads to the configured (unthrottled) Horizon removes that failure mode.
- **Blockaid:** a rate-limited Blockaid key (e.g. dev, ~1 req/s) makes the asset scan add seconds of retry latency to every balances call and floods logs (including a `TypeError` on dash-coded LP-token codes). An opt-out lets non-prod / high-throughput environments skip it. Scan failures are already non-fatal (caught → default `Benign`), so disabling only drops the enrichment, not balances.

## Notes
- Horizon override is gated on `network === "PUBLIC"` (the configured instance is a pubnet Horizon); testnet/futurenet keep their network defaults.
- `FREIGHTER_HORIZON_URL` previously only fed the health-check ping, not balances.
- New env var `DISABLE_BLOCKAID_ASSET_SCANNING` added to `ENV_KEYS`.

## Testing
- `tsc --noEmit` clean
- mercury test suite: 13 passed / 0 failed
- prettier clean