### PR TITLE
Migrate freighter-backend service builds to github actions

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -1,0 +1,67 @@
+name: Build and push freighter-backend (dev)
+
+# Deployed to: https://github.com/stellar/freighter-backend
+#
+# Converted from the Jenkins pipeline (Jenkinsfile-dev). Builds the
+# freighter-backend docker image and pushes it to the dev ECR repo
+# (dev/freighter-backend-dev:<sha>). The Jenkins job had no webhook trigger —
+# it was run manually — so this workflow is manual-dispatch only.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  SLACK_CHANNEL: ext-freighter-builds
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Determine image label
+        id: vars
+        run: echo "label=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: ECR login
+        id: ecr-login
+        uses: stellar/actions/sdf-ecr-login@main
+
+      - name: Build and push docker image
+        env:
+          ECR_REGISTRY: ${{ steps.ecr-login.outputs.ecr-registry }}
+          LABEL: ${{ steps.vars.outputs.label }}
+        run: |
+          set -eu
+          export TAG="${ECR_REGISTRY}/dev/freighter-backend-dev:${LABEL}"
+          make docker-build
+          ecr-push "${TAG}"
+
+      - name: Slack notification — success
+        if: success()
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ env.SLACK_CHANNEL }}",
+              "text": "Freighter backend *dev* build complete for ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}."
+            }
+
+      - name: Slack notification — failure
+        if: failure()
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ env.SLACK_CHANNEL }}",
+              "text": "Freighter backend *dev* build failed for ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}."
+            }

--- a/.github/workflows/build-stg.yml
+++ b/.github/workflows/build-stg.yml
@@ -1,0 +1,69 @@
+name: Build and push freighter-backend (stg)
+
+# Deployed to: https://github.com/stellar/freighter-backend
+#
+# Converted from the Jenkins pipeline (Jenkinsfile-stg). On every push to main
+# (or manual dispatch) builds the freighter-backend docker image and pushes it
+# to the stg ECR repo (stg/freighter-backend:<sha>).
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  SLACK_CHANNEL: ext-freighter-builds
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Determine image label
+        id: vars
+        run: echo "label=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: ECR login
+        id: ecr-login
+        uses: stellar/actions/sdf-ecr-login@main
+
+      - name: Build and push docker image
+        env:
+          ECR_REGISTRY: ${{ steps.ecr-login.outputs.ecr-registry }}
+          LABEL: ${{ steps.vars.outputs.label }}
+        run: |
+          set -eu
+          export TAG="${ECR_REGISTRY}/stg/freighter-backend:${LABEL}"
+          make docker-build
+          ecr-push "${TAG}"
+
+      - name: Slack notification — success
+        if: success()
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ env.SLACK_CHANNEL }}",
+              "text": "Freighter backend *stg* build complete for ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}."
+            }
+
+      - name: Slack notification — failure
+        if: failure()
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ env.SLACK_CHANNEL }}",
+              "text": "Freighter backend *stg* build failed for ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}."
+            }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,67 @@
+name: Build and push freighter-backend (prd)
+
+# Deployed to: https://github.com/stellar/freighter-backend
+#
+# Converted from the Jenkins pipeline (Jenkinsfile). Builds the freighter-backend
+# docker image and pushes it to the prd ECR repo (prd/freighter-backend:<sha>).
+# The Jenkins job had no webhook trigger — it was run manually — so this workflow
+# is manual-dispatch only.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  SLACK_CHANNEL: ext-freighter-builds
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Determine image label
+        id: vars
+        run: echo "label=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: ECR login
+        id: ecr-login
+        uses: stellar/actions/sdf-ecr-login@main
+
+      - name: Build and push docker image
+        env:
+          ECR_REGISTRY: ${{ steps.ecr-login.outputs.ecr-registry }}
+          LABEL: ${{ steps.vars.outputs.label }}
+        run: |
+          set -eu
+          export TAG="${ECR_REGISTRY}/prd/freighter-backend:${LABEL}"
+          make docker-build
+          ecr-push "${TAG}"
+
+      - name: Slack notification — success
+        if: success()
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ env.SLACK_CHANNEL }}",
+              "text": "Freighter backend *prd* build complete for ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}."
+            }
+
+      - name: Slack notification — failure
+        if: failure()
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ env.SLACK_CHANNEL }}",
+              "text": "Freighter backend *prd* build failed for ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}."
+            }


### PR DESCRIPTION
### What:

Migrate freighter-backend service builds to github actions

### Why:

We are moving builds to github actions.

### Issue:

https://github.com/stellar/ops/issues/4718